### PR TITLE
test: additional nodejs versions on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,8 +17,10 @@ cache:
 
 environment:
   matrix:
-    - nodejs_version: "6"
+    - nodejs_version: "0.12"
     - nodejs_version: "4"
+    - nodejs_version: "6"
+    - nodejs_version: "8"
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Adding nodejs 0.12 and 8 to the appveyor matrix