### PR TITLE
fix: use version from manifest

### DIFF
--- a/lib/formats/dotnet-cli-parser.js
+++ b/lib/formats/dotnet-cli-parser.js
@@ -27,6 +27,10 @@ function registerDependency(packageTree, resolvedName) {
 function parse(fileContent, packageTree) {
   var libraries = {};
   var manifest = JSON.parse(fileContent);
+  if (manifest.project) {
+    packageTree.version = manifest.project.version;
+    packageTree.from[0] = packageTree.name + '@' + packageTree.version;
+  }
   var targets = Object
     .keys(manifest.targets)
     .map(function (key) {
@@ -63,10 +67,6 @@ function parse(fileContent, packageTree) {
       })
     })
   });
-
-  if (manifest.project) {
-    packageTree.version = manifest.project.version;
-  }
 
   // restructure tree with "from" chains.
   function buildPath(node, from) {

--- a/test/stubs/dotnet_project/expected.json
+++ b/test/stubs/dotnet_project/expected.json
@@ -4,7 +4,7 @@
     "version": "1.0.0",
     "packageFormatVersion": "nuget:0.0.0",
     "from": [
-      "dotnet_project@0.0.0"
+      "dotnet_project@1.0.0"
     ],
     "dependencies": {
       "jQuery": {

--- a/test/stubs/dummy_project_2/expected.json
+++ b/test/stubs/dummy_project_2/expected.json
@@ -4,7 +4,7 @@
     "version": "2.2.2",
     "packageFormatVersion": "nuget:0.0.0",
     "from": [
-      "dummy_project_2@0.0.0"
+      "dummy_project_2@2.2.2"
     ],
     "dependencies": {
       "knockoutjs": {


### PR DESCRIPTION
fixes where default version is 0.0.0, but plugin happens to find manifest version - usage wasn't universal
now it is
includes updated tests