### PR TITLE
fix: path

### DIFF
--- a/dev-test.js
+++ b/dev-test.js
@@ -2,9 +2,9 @@ var parser = require('./lib');
 var fs = require('fs');
 
 parser
-  .inspect(null, './test/stubs/dummy_project_2/obj/project.assets.json', {
+  .inspect('./test/stubs/dummy_project_2', 'obj/project.assets.json', {
     packageManager: 'nuget',
-    packagesFolder: './test/stubs/dummy_project_2/_packages',
+    packagesFolder: '_packages',
   })
   .then(function (result) {
     if (!result) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,14 +21,13 @@ function determineManifestType (filename) {
       return 'packages.config';
     }
     case /.csproj$/.test(filename): {
-      return '.csproj'
+      return '.csproj';
     }
     default: {
       throw new Error('Could not determine manifest type for ' + filename);
     }
   }
 }
-
 function injectProjectData(packageTree, projectData) {
   packageTree.package.name = projectData.project.name;
   packageTree.package.version = projectData.project.version;
@@ -41,10 +40,8 @@ module.exports = {
     var nuspecResolutions = {};
     var manifestType;
     var fileContent;
-    var projectRootFolder = path.resolve(
-      root || '.',
-      targetFile || '.',
-      '../../');
+    var fileContentPath = path.resolve(root || '.', targetFile || '.');
+    var projectRootFolder = path.resolve(fileContentPath, '../../');
     if (options && options.packagesFolder) {
       packagesFolder = path.resolve(process.cwd(), options.packagesFolder);
     } else {
@@ -52,7 +49,7 @@ module.exports = {
     }
     try {
       manifestType = determineManifestType(path.basename(targetFile || root));
-      fileContent = fs.readFileSync(targetFile).toString();
+      fileContent = fs.readFileSync(fileContentPath).toString();
       debug('Loaded ' + targetFile + ' with manifest type ' + manifestType);
     }
     catch (error) {

--- a/test/parse-dotnet-cli-2.test.js
+++ b/test/parse-dotnet-cli-2.test.js
@@ -1,12 +1,12 @@
 var test = require('tap').test;
 var plugin = require('../lib/index');
-var projectPath = './test/stubs/dotnet_project/';
-var manifestFile = projectPath + 'obj/project.assets.json';
+var projectPath = './test/stubs/dotnet_project';
+var manifestFile = 'obj/project.assets.json';
 var expectedTree = require('./stubs/dotnet_project/expected.json');
 
 test('parse dotnet-cli 2 project and traverse packages', function (t) {
   plugin.inspect(
-    null,
+    projectPath,
     manifestFile)
     .then(function (result) {
       t.deepEqual(

--- a/test/parse-dotnet-cli-p-g.test.js
+++ b/test/parse-dotnet-cli-p-g.test.js
@@ -1,7 +1,8 @@
 var test = require('tap').test;
+var path = require('path');
 var plugin = require('../lib/index');
-var projectPath = './test/stubs/dotnet_p_g/';
-var manifestFile = projectPath + 'obj/project.assets.json';
+var projectPath = './test/stubs/dotnet_p_g';
+var manifestFile = 'obj/project.assets.json';
 var expectedTree = require('./stubs/dotnet_p_g/expected.json');
 
 test('parse dotnet-cli project and traverse packages', function (t) {
@@ -9,7 +10,7 @@ test('parse dotnet-cli project and traverse packages', function (t) {
     projectPath,
     manifestFile,
     {
-      packagesFolder: projectPath + './_packages',
+      packagesFolder: path.resolve(projectPath, '_packages'),
     })
     .then(function (result) {
       t.deepEqual(

--- a/test/parse-dotnet-cli.test.js
+++ b/test/parse-dotnet-cli.test.js
@@ -1,7 +1,7 @@
 var test = require('tap').test;
 var plugin = require('../lib/index');
 var projectPath = './test/stubs/dummy_project_2/';
-var manifestFile = projectPath + 'obj/project.assets.json';
+var manifestFile = 'obj/project.assets.json';
 var expectedTree = require('./stubs/dummy_project_2/expected.json');
 
 test('parse dotnet-cli project and traverse packages', function (t) {

--- a/test/parse-with-traverse.test.js
+++ b/test/parse-with-traverse.test.js
@@ -2,15 +2,13 @@ var test = require('tap').test;
 var fs = require('fs');
 
 var plugin = require('../lib/index');
-var stubProjectLocation = './test/stubs/dummy_project_1/';
+var targetProjectJsonFile = './test/stubs/dummy_project_1/';
 var targetPackagesConfigFile =
-  stubProjectLocation + 'dummy_project_1/packages.config';
+  targetProjectJsonFile + 'dummy_project_1/packages.config';
 var alternatePackagesFolder =
-  stubProjectLocation + 'alternate_packages';
+  targetProjectJsonFile + 'alternate_packages';
 var targetCSProjFile =
-  stubProjectLocation + 'dummy_project_1/WebApplication1.csproj';
-var targetJSONManifest =
-  './test/stubs/_2_project.json';
+  targetProjectJsonFile + 'dummy_project_1/WebApplication1.csproj';
 var targetJSONManifestData =
   require('./stubs/_2_project.json');
 
@@ -18,14 +16,14 @@ var targetJSONManifestData =
 test('parse project.assets.json - like and traverse packages', function (t) {
   var expectedTreeFile =
   fs.readFileSync(
-    stubProjectLocation + 'dummy_project_1/expected_csproj.json');
+    targetProjectJsonFile + 'dummy_project_1/expected_csproj.json');
   var expectedTree = JSON.parse(expectedTreeFile.toString());
   // NUnit can be referenced in .nuspec files.
   // In this test the manifest file has no NUnit reference,
   // therefor it is not expected to be in the result.
   delete expectedTree.package.dependencies.NUnit;
-  plugin.inspect(stubProjectLocation, targetJSONManifest, {
-    packagesFolder: stubProjectLocation + '/packages',
+  plugin.inspect(targetProjectJsonFile, '../_2_project.json', {
+    packagesFolder: targetProjectJsonFile + '/packages',
   }).then(function (result) {
     // In case project details are included in manifest file,
     // it's expected to be included in the 'package' section
@@ -46,11 +44,10 @@ test('parse project.assets.json - like and traverse packages', function (t) {
   });
 });
 
-
 test('parse .csproj and traverse packages', function (t) {
   var expectedTreeFile =
     fs.readFileSync(
-      stubProjectLocation + 'dummy_project_1/expected_csproj.json');
+      targetProjectJsonFile + 'dummy_project_1/expected_csproj.json');
   var expectedTree = JSON.parse(expectedTreeFile.toString());
 
   plugin.inspect(null, targetCSProjFile, null)
@@ -66,20 +63,20 @@ test('parse .csproj and traverse packages', function (t) {
       t.equal(result.plugin.targetFile, targetCSProjFile,
         'plugin shows correct targetFile');
       t.end();
-    })
+    });
     return result;
   })
   .then(function (result) {
     if (result) {
       t.end();
     }
-  })
+  });
 });
 
 test('parse packages.config and traverse packages', function (t) {
   var expectedTreeFile =
     fs.readFileSync(
-      stubProjectLocation + 'dummy_project_1/expected_pkgcfg.json');
+      targetProjectJsonFile + 'dummy_project_1/expected_pkgcfg.json');
   var expectedTree = JSON.parse(expectedTreeFile.toString());
 
   plugin.inspect(null, targetPackagesConfigFile, null)
@@ -91,21 +88,21 @@ test('parse packages.config and traverse packages', function (t) {
       t.ok(result.plugin);
       t.equal(result.plugin.name, 'snyk-nuget-plugin');
       t.end();
-    })
+    });
     return result;
   })
   .then(function (result) {
     if (result) {
       t.end();
     }
-  })
+  });
 });
 
 test('parse packages.config and traverse alternate packages folder',
   function (t) {
     var expectedTreeFile =
       fs.readFileSync(
-        stubProjectLocation + 'dummy_project_1/expected_pkgcfg.json');
+        targetProjectJsonFile + 'dummy_project_1/expected_pkgcfg.json');
     var expectedTree = JSON.parse(expectedTreeFile.toString());
 
     plugin.inspect(null, targetPackagesConfigFile, {
@@ -119,12 +116,12 @@ test('parse packages.config and traverse alternate packages folder',
         t.ok(result.plugin);
         t.equal(result.plugin.name, 'snyk-nuget-plugin');
         t.end();
-      })
+      });
       return result;
     })
     .then(function (result) {
       if (result) {
         t.end();
       }
-    })
+    });
   });

--- a/test/parse-without-traverse.test.js
+++ b/test/parse-without-traverse.test.js
@@ -2,7 +2,8 @@ var test = require('tap').test;
 var path = require('path');
 
 var plugin = require('../lib/index');
-var targetProjectJsonFile = './test/stubs/_1_project.json';
+var targetProjectJsonPath = './test/stubs';
+var targetProjectJsonFile = '_1_project.json';
 
 function createEmptyNode(name, version) {
   var resolvedPath = path.resolve(
@@ -15,7 +16,7 @@ function createEmptyNode(name, version) {
     version: version,
     versionSpec: 'unknown',
     dependencies: {},
-  }
+  };
 }
 
 function buildExpectedTree() {
@@ -39,7 +40,7 @@ function buildExpectedTree() {
 test('parse project.json file', function (t) {
   var expectedTree = buildExpectedTree();
 
-  plugin.inspect(null, targetProjectJsonFile, null)
+  plugin.inspect(targetProjectJsonPath, targetProjectJsonFile, null)
   .then(function (result) {
     t.test('plugin', function (t) {
       t.deepEqual(result.package.dependencies, expectedTree.dependencies);

--- a/test/stubs/dotnet_p_g/expected.json
+++ b/test/stubs/dotnet_p_g/expected.json
@@ -10733,6 +10733,6 @@
   },
   "plugin": {
     "name": "snyk-nuget-plugin",
-    "targetFile": "./test/stubs/dotnet_p_g/obj/project.assets.json"
+    "targetFile": "obj/project.assets.json"
   }
 }

--- a/test/stubs/dotnet_project/expected.json
+++ b/test/stubs/dotnet_project/expected.json
@@ -11327,6 +11327,6 @@
   },
   "plugin": {
     "name": "snyk-nuget-plugin",
-    "targetFile": "./test/stubs/dotnet_project/obj/project.assets.json"
+    "targetFile": "obj/project.assets.json"
   }
 }

--- a/test/stubs/dummy_project_2/expected.json
+++ b/test/stubs/dummy_project_2/expected.json
@@ -64,6 +64,6 @@
   },
   "plugin": {
     "name": "snyk-nuget-plugin",
-    "targetFile": "./test/stubs/dummy_project_2/obj/project.assets.json"
+    "targetFile": "obj/project.assets.json"
   }
 }


### PR DESCRIPTION
Problem fixed in this PR:
`snyk test folder_with_csproj_file_inside` fails - can't find file `something.csproj`

Works
`cd folder_with_csproj_file_inside`
`snyk test` or `snyk test --file=something.csproj`

Fixed by resolving the filename given with the path given