### PR TITLE
chore: update travis settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,10 @@ node_js:
   - "8"
   - "6"
   - "4"
-  - "0.12"
 cache:
   directories:
     - node_modules
 script:
-  - "npm install"
   - "npm run lint"
   - "npm test"
 jobs:


### PR DESCRIPTION
- remove 0.12 runtime from travis test matrix
- remove `npm install` from `script`, it runs automatically by travis