### PR TITLE
feat: check csproj version

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@ var parseNuspec = require('./nuspec-parser');
 var jsonManifestParser = require('./json-manifest-parser');
 var debug = require('debug')('snyk');
 var projectJsonFormatParser = require('./formats/dotnet-core-parser');
+var determineDotnetVersion = require('./proj-parser');
 
 function determineManifestType (filename) {
   switch (true) {
@@ -36,6 +37,7 @@ module.exports = {
     var nuspecResolutions = {};
     var manifestType;
     var fileContent;
+    var dotnetVersion;
     var fileContentPath = path.resolve(root || '.', targetFile || '.');
     var projectRootFolder = path.resolve(fileContentPath, '../../');
     if (options && options.packagesFolder) {
@@ -45,8 +47,16 @@ module.exports = {
     }
     try {
       manifestType = determineManifestType(path.basename(targetFile || root));
+      if (manifestType === 'dotnet-core') {
+        dotnetVersion = determineDotnetVersion(projectRootFolder);
+      } else {
+        // .csproj is in the same directory as packages.config or project.json
+        dotnetVersion = determineDotnetVersion(
+          path.resolve(fileContentPath, '../'));
+      }
       fileContent = fs.readFileSync(fileContentPath).toString();
-      debug('Loaded ' + targetFile + ' with manifest type ' + manifestType);
+      debug('Loaded ' + targetFile + ' with manifest type '
+        + manifestType + ' for .NET version ' + dotnetVersion);
     }
     catch (error) {
       return Promise.reject(error);

--- a/lib/proj-parser.js
+++ b/lib/proj-parser.js
@@ -1,0 +1,71 @@
+const fs = require('fs');
+const path = require('path');
+const parseXML = require('xml2js').parseString;
+const debug = require('debug')('snyk');
+const _ = require('lodash');
+
+function determineDotnetVersion(rootDir) {
+  debug('Looking for your .csproj file in ' + rootDir);
+  const csprojPath = findFile(rootDir, /.*\.csproj$/);
+  if (!csprojPath) {
+    throw new Error('.csproj file not found in ' + rootDir + '. ' +
+      'Make sure project was built before running `snyk test`');
+  }
+  debug('Checking .net framework version in .csproj file ' + csprojPath);
+
+  const csprojContents = fs.readFileSync(csprojPath);
+
+  var frameworks = [];
+  parseXML(csprojContents, function (err, parsedCsprojContents) {
+    if (err) {
+      throw err;
+    }
+    const versionLoc = _.get(parsedCsprojContents, 'Project.PropertyGroup[0]');
+    const versions = _.compact(_.concat([],
+      _.get(versionLoc, 'TargetFrameworkVersion[0]') ||
+      _.get(versionLoc, 'TargetFramework[0]') ||
+      _.get(versionLoc, 'TargetFrameworks[0]', '').split(';')));
+
+    if (versions.length < 1) {
+      throw new Error('Could not find TargetFrameworkVersion/TargetFramework' +
+        '/TargetFrameworks defined in the Project.PropertyGroup field of ' +
+        'your .csproj file');
+    }
+    frameworks = _.compact(_.map(versions, toReadableVersion));
+  });
+  if (frameworks.length < 1) {
+    throw new Error('Could not find valid/supported .NET version');
+  }
+  return frameworks;
+}
+
+function toReadableVersion(version) {
+  const typeMapping = {
+    v: '.NETFramework',
+    net: '.NETFramework',
+    netstandard: '.NETStandard',
+    netcoreapp: '.NETCore',
+  };
+
+  for (var type in typeMapping) {
+    if (new RegExp(type + /\d.?\d(.?\d)?$/.source).test(version)) {
+      return typeMapping[type] + version.split(type)[1];
+    }
+  }
+}
+
+function findFile(rootDir, filter) {
+  if (!fs.existsSync(rootDir)) {
+    throw new Error('No such path: ' + rootDir);
+  }
+  const files = fs.readdirSync(rootDir);
+  for (var i = 0; i < files.length; i++) {
+    var filename = path.resolve(rootDir, files[i]);
+
+    if (filter.test(filename)) {
+      return filename;
+    }
+  }
+}
+
+module.exports = determineDotnetVersion;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "debug": "^3.1.0",
     "es6-promise": "^4.1.1",
     "xml2js": "^0.4.17",
-    "zip": "^1.2.0"
+    "zip": "^1.2.0",
+    "lodash": "^4.17.10"
   },
   "devDependencies": {
     "jscs": "^3.0.7",

--- a/test/csproj.test.js
+++ b/test/csproj.test.js
@@ -1,0 +1,68 @@
+var test = require('tap').test;
+var plugin = require('../lib/index');
+var multipleFrameworksPath = './test/stubs/target_framework/csproj_multiple/';
+var noProjectPath = './test/stubs/target_framework/no_csproj/';
+var noFrameworksPath = './test/stubs/target_framework/no_target_framework';
+var noValidFrameworksPath =
+  './test/stubs/target_framework/no_target_valid_framework';
+var manifestFile = 'obj/project.assets.json';
+var expectedTree =
+  require('./stubs/target_framework/csproj_multiple/expected.json');
+
+test('parse dotnet with csproj containing multiple versions', function (t) {
+  plugin.inspect(
+    multipleFrameworksPath,
+    manifestFile)
+    .then(function (result) {
+      t.deepEqual(
+        result,
+        expectedTree,
+        'expects project data to be correct'
+      );
+      t.end();
+    })
+    .catch(function () {
+      t.fail('Error was thrown: ' + err);
+    });
+});
+
+test('parse dotnet with vbproj', function (t) {
+  plugin.inspect(
+    noProjectPath,
+    manifestFile)
+    .then(function () {
+      t.fail('Expected error to be thrown!');
+    })
+    .catch(function (err) {
+      t.ok(/\.csproj file not found.*/.test(err.toString()), 'expected error');
+      t.end();
+    });
+});
+
+test('parse dotnet without any target framework fields', function (t) {
+  plugin.inspect(
+    noFrameworksPath,
+    manifestFile)
+    .then(function () {
+      t.fail('Expected error to be thrown!');
+    })
+    .catch(function (err) {
+      t.ok(/Could not find TargetFrameworkVersion.*/
+        .test(err.toString()), 'expected error');
+      t.end();
+    });
+});
+
+test('parse dotnet with no valid framework defined', function (t) {
+  plugin.inspect(
+    noValidFrameworksPath,
+    manifestFile)
+    .then(function () {
+      t.fail('Expected error to be thrown!');
+    })
+    .catch(function (err) {
+      t.ok(/Could not find valid\/supported \.NET version.*/
+        .test(err.toString()), 'expected error');
+      t.end();
+    });
+});

--- a/test/stubs/dotnet_2/dotnet_2.csproj
+++ b/test/stubs/dotnet_2/dotnet_2.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.108" />
+  </ItemGroup>
+</Project>

--- a/test/stubs/dotnet_p_g/dotnet_p_g.csproj
+++ b/test/stubs/dotnet_p_g/dotnet_p_g.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.108" />
+  </ItemGroup>
+</Project>

--- a/test/stubs/dotnet_project/dotnet_project.csproj
+++ b/test/stubs/dotnet_project/dotnet_project.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.108" />
+  </ItemGroup>
+</Project>

--- a/test/stubs/dummy_project_2/dummy_project_2.csproj
+++ b/test/stubs/dummy_project_2/dummy_project_2.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.108" />
+  </ItemGroup>
+</Project>

--- a/test/stubs/packages_dir/only_jquery/only_jquery.csproj
+++ b/test/stubs/packages_dir/only_jquery/only_jquery.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.108" />
+  </ItemGroup>
+</Project>

--- a/test/stubs/packages_dir/only_jquery_but_wrong_version/only_jquery_but_wrong_version.csproj
+++ b/test/stubs/packages_dir/only_jquery_but_wrong_version/only_jquery_but_wrong_version.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.108" />
+  </ItemGroup>
+</Project>

--- a/test/stubs/packages_dir/only_momentjs/only_moment.csproj
+++ b/test/stubs/packages_dir/only_momentjs/only_moment.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.108" />
+  </ItemGroup>
+</Project>

--- a/test/stubs/stubs.csproj
+++ b/test/stubs/stubs.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.108" />
+  </ItemGroup>
+</Project>

--- a/test/stubs/target_framework/csproj_multiple/csproj_multiple.csproj
+++ b/test/stubs/target_framework/csproj_multiple/csproj_multiple.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.0;net462</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.108" />
+  </ItemGroup>
+</Project>

--- a/test/stubs/target_framework/csproj_multiple/expected.json
+++ b/test/stubs/target_framework/csproj_multiple/expected.json
@@ -1,0 +1,39 @@
+{
+  "package": {
+    "name": "csproj_multiple",
+    "version": "2.2.2",
+    "packageFormatVersion": "nuget:0.0.0",
+    "dependencies": {
+      "knockoutjs": {
+        "name": "knockoutjs",
+        "version": "2.3.0",
+        "dependencies": {}
+      },
+      "Knockout.Validation": {
+        "name": "Knockout.Validation",
+        "version": "1.0.1",
+        "dependencies": {
+          "knockoutjs": {
+            "name": "knockoutjs",
+            "version": "2.3.0",
+            "dependencies": {}
+          },
+          "jQuery": {
+            "name": "jQuery",
+            "version": "1.10.2",
+            "dependencies": {}
+          }
+        }
+      },
+      "jQuery": {
+        "name": "jQuery",
+        "version": "1.10.2",
+        "dependencies": {}
+      }
+    }
+  },
+  "plugin": {
+    "name": "snyk-nuget-plugin",
+    "targetFile": "obj/project.assets.json"
+  }
+}

--- a/test/stubs/target_framework/csproj_multiple/obj/project.assets.json
+++ b/test/stubs/target_framework/csproj_multiple/obj/project.assets.json
@@ -1,0 +1,21 @@
+{
+    "version": 3,
+    "targets": {
+        "Microsoft.NETCore.App/2.0.0": {
+            "Knockout.Validation/1.0.1": {
+                "dependencies": {
+                    "knockoutjs": "2.3.0",
+                    "jQuery": "1.10.2"
+                }
+            }
+        }
+    },
+    "libraries": {
+        "knockoutjs/2.3.0": {},
+        "Knockout.Validation/1.0.1": {},
+        "jQuery/1.10.2": {}
+    },
+    "project": {
+        "version": "2.2.2"
+    }
+}

--- a/test/stubs/target_framework/no_csproj/no_csproj.vbproj
+++ b/test/stubs/target_framework/no_csproj/no_csproj.vbproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.108" />
+  </ItemGroup>
+</Project>

--- a/test/stubs/target_framework/no_csproj/obj/project.assets.json
+++ b/test/stubs/target_framework/no_csproj/obj/project.assets.json
@@ -1,0 +1,21 @@
+{
+    "version": 3,
+    "targets": {
+        "Microsoft.NETCore.App/2.0.0": {
+            "Knockout.Validation/1.0.1": {
+                "dependencies": {
+                    "knockoutjs": "2.3.0",
+                    "jQuery": "1.10.2"
+                }
+            }
+        }
+    },
+    "libraries": {
+        "knockoutjs/2.3.0": {},
+        "Knockout.Validation/1.0.1": {},
+        "jQuery/1.10.2": {}
+    },
+    "project": {
+        "version": "2.2.2"
+    }
+}

--- a/test/stubs/target_framework/no_target_framework/no_target_framework.csproj
+++ b/test/stubs/target_framework/no_target_framework/no_target_framework.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+  </PropertyGroup>
+  <ItemGroup>
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.108" />
+  </ItemGroup>
+</Project>

--- a/test/stubs/target_framework/no_target_framework/obj/project.assets.json
+++ b/test/stubs/target_framework/no_target_framework/obj/project.assets.json
@@ -1,0 +1,21 @@
+{
+    "version": 3,
+    "targets": {
+        "Microsoft.NETCore.App/2.0.0": {
+            "Knockout.Validation/1.0.1": {
+                "dependencies": {
+                    "knockoutjs": "2.3.0",
+                    "jQuery": "1.10.2"
+                }
+            }
+        }
+    },
+    "libraries": {
+        "knockoutjs/2.3.0": {},
+        "Knockout.Validation/1.0.1": {},
+        "jQuery/1.10.2": {}
+    },
+    "project": {
+        "version": "2.2.2"
+    }
+}

--- a/test/stubs/target_framework/no_target_valid_framework/no_target_valid_framework.csproj
+++ b/test/stubs/target_framework/no_target_valid_framework/no_target_valid_framework.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+      <TargetFrameworks>totesnotvalid2.0;totesmagotes462</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.108" />
+  </ItemGroup>
+</Project>

--- a/test/stubs/target_framework/no_target_valid_framework/obj/project.assets.json
+++ b/test/stubs/target_framework/no_target_valid_framework/obj/project.assets.json
@@ -1,0 +1,21 @@
+{
+    "version": 3,
+    "targets": {
+        "Microsoft.NETCore.App/2.0.0": {
+            "Knockout.Validation/1.0.1": {
+                "dependencies": {
+                    "knockoutjs": "2.3.0",
+                    "jQuery": "1.10.2"
+                }
+            }
+        }
+    },
+    "libraries": {
+        "knockoutjs/2.3.0": {},
+        "Knockout.Validation/1.0.1": {},
+        "jQuery/1.10.2": {}
+    },
+    "project": {
+        "version": "2.2.2"
+    }
+}


### PR DESCRIPTION
Added a dependency on the csproj file for the plugin to run properly. Currently it terminates if the version of the .NET framework is unsupported or we can't find it (along with a helpful error//debug statement)

In the future the version will be used to determine the correct dependencies to pull from the packages nuspec files in case of an older .NET framework project.

Most of the file additions in this PR are .csproj files that were needed for the tests to pass.