### PR TITLE
fix: locate lock file relative to dependencies file

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,7 +47,7 @@ module.exports = {
       return paketParser.buildDepTreeFromFiles(
         root,
         targetFile,
-        path.resolve(path.dirname(fileContentPath), 'paket.lock'),
+        path.join(path.dirname(targetFile), 'paket.lock'),
         options['include-dev'],
         options.strict
       ).then(createPackageTree);

--- a/lib/index.js
+++ b/lib/index.js
@@ -47,7 +47,7 @@ module.exports = {
       return paketParser.buildDepTreeFromFiles(
         root,
         targetFile,
-        options['lock-file-path'] || 'paket.lock',
+        path.resolve(path.dirname(fileContentPath), 'paket.lock'),
         options['include-dev'],
         options.strict
       ).then(createPackageTree);

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "debug": "^3.1.0",
     "jszip": "^3.1.5",
     "lodash": "^4.17.10",
-    "snyk-paket-parser": "1.4.1",
+    "snyk-paket-parser": "1.4.3",
     "xml2js": "^0.4.17"
   },
   "devDependencies": {

--- a/test/paket.test.js
+++ b/test/paket.test.js
@@ -2,7 +2,9 @@ var test = require('tap').test;
 var plugin = require('../lib/index');
 var path = require('path');
 
-var simplePaket = './test/stubs/simple-paket/';
+var stubsDir = './test/stubs';
+var simplePaket = stubsDir + '/simple-paket/';
+var missingLock = stubsDir + '/paket-missing-lock/';
 
 var simplePaketDeps = {
   'FSharp.Formatting': {
@@ -41,10 +43,33 @@ var simplePaketDeps = {
 
 
 test('parse simple-paket project', function (t) {
-  plugin.inspect(simplePaket, 'paket.dependencies')
+  return plugin.inspect(simplePaket, 'paket.dependencies')
     .then(function (tree) {
       t.deepEquals(tree.package.dependencies, simplePaketDeps, 'expected dependencies');
       t.equals(tree.package.name, path.resolve(simplePaket, 'paket.dependencies'), 'correct name');
       t.end();
+    }).catch(function (err) {
+      t.fail('did not expect error' + err);
     });
+});
+
+test('parse simple-paket project from upper dir', function (t) {
+  return plugin.inspect(stubsDir, 'simple-paket/paket.dependencies')
+    .then(function (tree) {
+      t.deepEquals(tree.package.dependencies, simplePaketDeps, 'expected dependencies');
+      t.equals(tree.package.name, path.resolve(simplePaket, 'paket.dependencies'), 'correct name');
+      t.end();
+    }).catch(function (err) {
+      t.fail('did not expect error ' + err);
+    });
+});
+
+test('fail to parse paket with missing lock file project', function (t) {
+  plugin.inspect(missingLock, 'paket.dependencies')
+    .then(function () {
+      t.fail('expected error');
+    }).catch(function (err) {
+      t.ok(/Lockfile not found at location.*/.test(err.toString()), 'expected error');
+      t.end();
+  });
 });

--- a/test/paket.test.js
+++ b/test/paket.test.js
@@ -43,10 +43,10 @@ var simplePaketDeps = {
 
 
 test('parse simple-paket project', function (t) {
-  return plugin.inspect(simplePaket, 'paket.dependencies')
+  plugin.inspect(simplePaket, 'paket.dependencies')
     .then(function (tree) {
       t.deepEquals(tree.package.dependencies, simplePaketDeps, 'expected dependencies');
-      t.equals(tree.package.name, path.resolve(simplePaket, 'paket.dependencies'), 'correct name');
+      t.equals(tree.package.name, 'simple-paket', 'correct name');
       t.end();
     }).catch(function (err) {
       t.fail('did not expect error' + err);
@@ -54,10 +54,10 @@ test('parse simple-paket project', function (t) {
 });
 
 test('parse simple-paket project from upper dir', function (t) {
-  return plugin.inspect(stubsDir, 'simple-paket/paket.dependencies')
+  plugin.inspect(stubsDir, 'simple-paket/paket.dependencies')
     .then(function (tree) {
       t.deepEquals(tree.package.dependencies, simplePaketDeps, 'expected dependencies');
-      t.equals(tree.package.name, path.resolve(simplePaket, 'paket.dependencies'), 'correct name');
+      t.equals(tree.package.name, 'simple-paket', 'correct name');
       t.end();
     }).catch(function (err) {
       t.fail('did not expect error ' + err);
@@ -71,5 +71,5 @@ test('fail to parse paket with missing lock file project', function (t) {
     }).catch(function (err) {
       t.ok(/Lockfile not found at location.*/.test(err.toString()), 'expected error');
       t.end();
-  });
+    });
 });

--- a/test/stubs/paket-missing-lock/paket.dependencies
+++ b/test/stubs/paket-missing-lock/paket.dependencies
@@ -1,0 +1,5 @@
+redirects: on
+source https://nuget.org/api/v2
+
+nuget FSharp.Formatting
+nuget FAKE


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Fixes issue where we set the `--file` flag from a different directory (`--file='./path/to/file.txt`) and the lock file was not found in the directory (`.`)
