### PR TITLE
fix: succeed even if csproj not found in manifest file path

### DIFF
--- a/lib/nuget-parser/csproj-parser.js
+++ b/lib/nuget-parser/csproj-parser.js
@@ -8,36 +8,35 @@ const _ = require('lodash');
 function getTargetFrameworksFromProjFile(rootDir) {
   debug('Looking for your .csproj file in ' + rootDir);
   const csprojPath = findFile(rootDir, /.*\.csproj$/);
-  if (!csprojPath) {
-    throw new Error('.csproj file not found in ' + rootDir + '. ' +
-      'Make sure project was built before running `snyk test`');
+  if (csprojPath) {
+    debug('Checking .net framework version in .csproj file ' + csprojPath);
+
+    const csprojContents = fs.readFileSync(csprojPath);
+
+    let frameworks = [];
+    parseXML(csprojContents, function (err, parsedCsprojContents) {
+      if (err) {
+        throw err;
+      }
+      const versionLoc = _.get(parsedCsprojContents, 'Project.PropertyGroup[0]');
+      const versions = _.compact(_.concat([],
+        _.get(versionLoc, 'TargetFrameworkVersion[0]') ||
+        _.get(versionLoc, 'TargetFramework[0]') ||
+        _.get(versionLoc, 'TargetFrameworks[0]', '').split(';')));
+
+      if (versions.length < 1) {
+        debug('Could not find TargetFrameworkVersion/TargetFramework' +
+          '/TargetFrameworks defined in the Project.PropertyGroup field of ' +
+          'your .csproj file');
+      }
+      frameworks = _.compact(_.map(versions, toReadableFramework));
+      if (versions.length > 1 && frameworks.length < 1) {
+        debug('Could not find valid/supported .NET version in csproj file located at' + csprojPath);
+      }
+    });
+    return frameworks[0];
   }
-  debug('Checking .net framework version in .csproj file ' + csprojPath);
-
-  const csprojContents = fs.readFileSync(csprojPath);
-
-  let frameworks = [];
-  parseXML(csprojContents, function (err, parsedCsprojContents) {
-    if (err) {
-      throw err;
-    }
-    const versionLoc = _.get(parsedCsprojContents, 'Project.PropertyGroup[0]');
-    const versions = _.compact(_.concat([],
-      _.get(versionLoc, 'TargetFrameworkVersion[0]') ||
-      _.get(versionLoc, 'TargetFramework[0]') ||
-      _.get(versionLoc, 'TargetFrameworks[0]', '').split(';')));
-
-    if (versions.length < 1) {
-      debug('Could not find TargetFrameworkVersion/TargetFramework' +
-        '/TargetFrameworks defined in the Project.PropertyGroup field of ' +
-        'your .csproj file');
-    }
-    frameworks = _.compact(_.map(versions, toReadableFramework));
-    if (versions.length > 1 && frameworks.length < 1) {
-      throw new Error('Could not find valid/supported .NET version in csproj file located at' + csprojPath);
-    }
-  });
-  return frameworks[0];
+  debug('.csproj file not found in ' + rootDir + '.');
 }
 
 function toReadableFramework(targetFramework) {

--- a/test/csproj.test.js
+++ b/test/csproj.test.js
@@ -9,10 +9,10 @@ const noValidFrameworksPath =
   './test/stubs/target_framework/no_target_valid_framework';
 const manifestFile = 'obj/project.assets.json';
 
-test('parse dotnet with csproj containing multiple versions', function (t) {
+test('parse dotnet with csproj containing multiple versions retrieves first one', function (t) {
   const dotnetVersions = determineDotnetVersion(
     multipleFrameworksPath);
-  t.ok(dotnetVersions, ['.NETCore2.0','.NETFramework462']);
+  t.equal('netcoreapp2.0', dotnetVersions.original);
   t.end();
 });
 
@@ -20,11 +20,9 @@ test('parse dotnet with vbproj', function (t) {
   plugin.inspect(
     noProjectPath,
     manifestFile)
-    .then(function () {
-      t.fail('Expected error to be thrown!');
-    })
-    .catch(function (err) {
-      t.ok(/\.csproj file not found.*/.test(err.toString()), 'expected error');
+    .then(function (res) {
+      t.equal(res.package.name, 'no_csproj');
+      t.equal(res.plugin.targetRuntime, 'netcoreapp2.0');
       t.end();
     });
 });
@@ -37,8 +35,7 @@ test('parse dotnet with no valid framework defined', function (t) {
       t.fail('Expected error to be thrown!');
     })
     .catch(function (err) {
-      t.ok(/Could not find valid\/supported \.NET version.*/
-        .test(err.toString()), 'expected error');
+      t.equal(err.message, 'No frameworks were found in project.assets.json', 'expected error');
       t.end();
     });
 });

--- a/test/stubs/target_framework/no_csproj/obj/project.assets.json
+++ b/test/stubs/target_framework/no_csproj/obj/project.assets.json
@@ -1,21 +1,178 @@
 {
-    "version": 3,
-    "targets": {
-        "Microsoft.NETCore.App/2.0.0": {
-            "Knockout.Validation/1.0.1": {
-                "dependencies": {
-                    "knockoutjs": "2.3.0",
-                    "jQuery": "1.10.2"
-                }
-            }
+  "version": 2,
+  "targets": {
+    ".NETCoreApp,Version=v2.0": {
+      "jQuery/1.10.2": {
+        "type": "package"
+      },
+      "Libuv/1.10.0": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1"
+        },
+        "runtimeTargets": {
+          "runtimes/linux-arm/native/libuv.so": {
+            "assetType": "native",
+            "rid": "linux-arm"
+          },
+          "runtimes/linux-arm64/native/libuv.so": {
+            "assetType": "native",
+            "rid": "linux-arm64"
+          },
+          "runtimes/linux-armel/native/libuv.so": {
+            "assetType": "native",
+            "rid": "linux-armel"
+          },
+          "runtimes/linux-x64/native/libuv.so": {
+            "assetType": "native",
+            "rid": "linux-x64"
+          },
+          "runtimes/osx/native/libuv.dylib": {
+            "assetType": "native",
+            "rid": "osx"
+          },
+          "runtimes/win-arm/native/libuv.dll": {
+            "assetType": "native",
+            "rid": "win-arm"
+          },
+          "runtimes/win-x64/native/libuv.dll": {
+            "assetType": "native",
+            "rid": "win-x64"
+          },
+          "runtimes/win-x86/native/libuv.dll": {
+            "assetType": "native",
+            "rid": "win-x86"
+          }
         }
-    },
-    "libraries": {
-        "knockoutjs/2.3.0": {},
-        "Knockout.Validation/1.0.1": {},
-        "jQuery/1.10.2": {}
-    },
-    "project": {
-        "version": "2.2.2"
+      },
+      "Newtonsoft.Json/10.0.1": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.CSharp": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.ComponentModel.TypeConverter": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Dynamic.Runtime": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Numerics": "4.3.0",
+          "System.Runtime.Serialization.Formatters": "4.3.0",
+          "System.Runtime.Serialization.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Text.RegularExpressions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Xml.ReaderWriter": "4.3.0",
+          "System.Xml.XDocument": "4.3.0",
+          "System.Xml.XmlDocument": "4.3.0"
+        },
+        "compile": {
+          "lib/netstandard1.3/Newtonsoft.Json.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/Newtonsoft.Json.dll": {}
+        }
+      },
+      "Newtonsoft.Json.Bson/1.0.1": {
+        "type": "package",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1",
+          "Newtonsoft.Json": "10.0.1"
+        },
+        "compile": {
+          "lib/netstandard1.3/Newtonsoft.Json.Bson.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/Newtonsoft.Json.Bson.dll": {}
+        }
+      }
     }
+  },
+  "libraries": {
+    "Microsoft.Extensions.Logging.TraceSource/2.0.0": {
+      "sha512": "lbNYFjLU4RJvhYtO5jLa+d+T8OC495SkSfXFwFDeR9qtFqhrrCHe8Htjx4wR8HmFqugaJ2Yhzw9AqdvZbEy3Eg==",
+      "type": "package",
+      "path": "microsoft.extensions.logging.tracesource/2.0.0",
+      "files": [
+        "lib/netstandard2.0/Microsoft.Extensions.Logging.TraceSource.dll",
+        "lib/netstandard2.0/Microsoft.Extensions.Logging.TraceSource.xml",
+        "microsoft.extensions.logging.tracesource.2.0.0.nupkg.sha512",
+        "microsoft.extensions.logging.tracesource.nuspec"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    ".NETCoreApp,Version=v2.0": [
+      "Microsoft.AspNetCore.All >= 2.0.0",
+      "Microsoft.NETCore.App >= 2.0.0",
+      "NUnit.Runners >= 3.7.0",
+      "jquery >= 1.10.2"
+    ]
+  },
+  "packageFolders": {
+    "/home/aryeh/.nuget/packages/": {}
+  },
+  "project": {
+    "version": "1.0.0",
+    "restore": {
+      "projectUniqueName": "/home/aryeh/.workspace/snyk-workspace/nuget/dotnet_cmd_linux_web/dotnet_cmd_linux_web.csproj",
+      "projectName": "dotnet_cmd_linux_web",
+      "projectPath": "/home/aryeh/.workspace/snyk-workspace/nuget/dotnet_cmd_linux_web/dotnet_cmd_linux_web.csproj",
+      "outputPath": "/home/aryeh/.workspace/snyk-workspace/nuget/dotnet_cmd_linux_web/obj",
+      "projectStyle": "PackageReference",
+      "originalTargetFrameworks": [
+        "netcoreapp2.0"
+      ],
+      "frameworks": {
+        "netcoreapp2.0": {
+          "projectReferences": {}
+        }
+      }
+    },
+    "frameworks": {
+      "netcoreapp2.0": {
+        "dependencies": {
+          "Microsoft.NETCore.App": {
+            "target": "Package",
+            "version": "2.0"
+          },
+          "jquery": {
+            "target": "Package",
+            "version": "1.10.2"
+          },
+          "Microsoft.AspNetCore.All": {
+            "target": "Package",
+            "version": "2.0.0"
+          },
+          "NUnit.Runners": {
+            "target": "Package",
+            "version": "3.7.0"
+          }
+        },
+        "imports": [
+          "net461"
+        ]
+      }
+    },
+    "runtimes": {
+      "win": {
+        "#import": []
+      },
+      "win-x64": {
+        "#import": []
+      },
+      "win-x86": {
+        "#import": []
+      }
+    }
+  }
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Large nuget projects might not have their csproj file next to their obj/project.assets.json file. The paths to each of the files is listed in a properties file that we don't parse yet. Since we don't require the target framework from the csproj, yet, we can stop failing if we can't find the csproj where we expect it. This PR allows such projects to succeed when sending --file=path/to/project.assets.json flag. 

#### Where should the reviewer start?
https://github.com/snyk/snyk-nuget-plugin/issues/41