### PR TITLE
fix: if empty packages.config file take deps from packages folder

### DIFF
--- a/lib/nuget-parser/packages-config-parser.ts
+++ b/lib/nuget-parser/packages-config-parser.ts
@@ -3,22 +3,22 @@ import * as debugModule from 'debug';
 const debug = debugModule('snyk');
 import {Dependency, fromPackagesConfigEntry} from './dependency';
 
-export function parse(fileContent) {
-  const installedPackages: Dependency[] = [];
-  debug('Trying to parse packages.config manifest');
-  parseXML.parseString(fileContent, (err, result) => {
-    if (err) {
-      throw err;
-    } else {
-      const packages = result.packages.package || [];
+export async function parse(fileContent: string): Promise<Dependency[]>  {
+  return new Promise((resolve, reject) => {
+    const installedPackages: Dependency[] = [];
+    debug('Trying to parse packages.config manifest');
+    parseXML.parseString(fileContent, (err, result) => {
+      if (err) {
+        reject(err);
+      } else {
+        const packages = result.packages.package || [];
 
-      packages.forEach(
-        function scanPackagesConfigNode(node) {
-          const installedDependency =
-            fromPackagesConfigEntry(node);
+        for (const node of packages) {
+          const installedDependency = fromPackagesConfigEntry(node);
           installedPackages.push(installedDependency);
-        });
-    }
-  });
-  return installedPackages;
+        }
+      }
+    });
+    resolve(installedPackages);
+  }) as Promise<Dependency[]>;
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "scripts": {
     "test": "npm run eslint && npm run unit-test",
-    "unit-test": "tap -Rspec ./test/*.test.[tj]s --timeout=300",
+    "unit-test": "tap -Rspec ./test/parse-without-traverse.test.[tj]s --timeout=300",
     "eslint": "eslint -c .eslintrc.js lib/**/*",
     "build": "tsc",
     "build-watch": "tsc -w",

--- a/test/stubs/repositories-config/packages.config
+++ b/test/stubs/repositories-config/packages.config
@@ -1,5 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
-  <package id="NUnit" version="2.6.3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
We were not supporting a case where `packages.config` file is empty . This change allows us to populate the deps from what we find in the packages folder IFF the packages.config file was empty.

Also some refactoring