### PR TITLE
Feat/scan dotnet with missing proj

### DIFF
--- a/lib/nuget-parser/csproj-parser.ts
+++ b/lib/nuget-parser/csproj-parser.ts
@@ -5,16 +5,11 @@ import * as path from 'path';
 import * as parseXML from 'xml2js';
 import * as _ from 'lodash';
 import * as debugModule from 'debug';
+import { TargetFramework } from './types';
 const debug = debugModule('snyk');
 
-interface TargetFramework {
-  framework: string;
-  original: string;
-  version: string;
-}
-
-export async function getTargetFrameworksFromProjFile(rootDir: string): Promise<any> {
-  return new Promise((resolve, reject) => {
+export async function getTargetFrameworksFromProjFile(rootDir: string): Promise<TargetFramework | undefined> {
+  return new Promise<TargetFramework | undefined>((resolve, reject) => {
     debug('Looking for your .csproj file in ' + rootDir);
     const csprojPath = findFile(rootDir, /.*\.csproj$/);
     if (csprojPath) {

--- a/lib/nuget-parser/csproj-parser.ts
+++ b/lib/nuget-parser/csproj-parser.ts
@@ -6,6 +6,7 @@ import * as parseXML from 'xml2js';
 import * as _ from 'lodash';
 import * as debugModule from 'debug';
 import { TargetFramework } from './types';
+import { toReadableFramework } from './framework';
 const debug = debugModule('snyk');
 
 export async function getTargetFrameworksFromProjFile(rootDir: string): Promise<TargetFramework | undefined> {
@@ -43,25 +44,6 @@ export async function getTargetFrameworksFromProjFile(rootDir: string): Promise<
     debug('.csproj file not found in ' + rootDir + '.');
     resolve();
   });
-}
-
-function toReadableFramework(targetFramework: string): TargetFramework | undefined {
-  const typeMapping = {
-    net: '.NETFramework',
-    netcoreapp: '.NETCore',
-    netstandard: '.NETStandard',
-    v: '.NETFramework',
-  };
-
-  for (const type in typeMapping) {
-    if (new RegExp(type + /\d.?\d(.?\d)?$/.source).test(targetFramework)) {
-      return {
-        framework: typeMapping[type],
-        original: targetFramework,
-        version: targetFramework.split(type)[1],
-      };
-    }
-  }
 }
 
 function findFile(rootDir, filter) {

--- a/lib/nuget-parser/framework.ts
+++ b/lib/nuget-parser/framework.ts
@@ -1,0 +1,23 @@
+import { TargetFramework } from "./types";
+
+export function toReadableFramework(targetFramework: string): TargetFramework | undefined {
+  const typeMapping = {
+    net: '.NETFramework',
+    netcoreapp: '.NETCore',
+    netstandard: '.NETStandard',
+    v: '.NETFramework',
+  };
+
+  for (const type in typeMapping) {
+    if (new RegExp(type + /\d.?\d(.?\d)?$/.source).test(targetFramework)) {
+      return {
+        framework: typeMapping[type],
+        original: targetFramework,
+        version: targetFramework.split(type)[1],
+      };
+    }
+  }
+
+  return undefined;
+}
+  

--- a/lib/nuget-parser/types.ts
+++ b/lib/nuget-parser/types.ts
@@ -1,0 +1,5 @@
+export interface TargetFramework {
+  framework: string;
+  original: string;
+  version: string;
+}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "homepage": "https://github.com/snyk/snyk-nuget-plugin#readme",
   "dependencies": {
     "debug": "^3.1.0",
+    "dotnet-deps-parser": "4.5.0",
     "jszip": "^3.1.5",
     "lodash": "^4.17.14",
     "snyk-paket-parser": "1.5.0",

--- a/test/nuget-parser.test.ts
+++ b/test/nuget-parser.test.ts
@@ -1,0 +1,64 @@
+import * as tap from 'tap';
+const test = tap.test;
+import { getMinimumTargetFrameworkFromPackagesConfig } from '../lib/nuget-parser';
+
+test('various error handling is performed for getMinimumTargetFrameworkFromPackagesConfig', async (t) => {
+  // give bad content and expect to throw
+  const malformedXml = '<hello></bye>';
+  try {
+    await getMinimumTargetFrameworkFromPackagesConfig(malformedXml);
+    t.fail('expected to throw on malformed xml');
+  } catch (error) {
+    t.pass('expected to throw on malformed xml');
+  }
+  
+  // give empty content and expect undefined
+  try {
+    const result = await getMinimumTargetFrameworkFromPackagesConfig('');
+    t.pass('expected not to throw on empty content');
+    t.deepEqual(result, undefined, 'should return undefined on empty content');
+  } catch (error) {
+    t.fail('expected not to throw on empty content');
+  }
+
+  // give no packages but don't expect to throw
+  const noPackages = `
+    <?xml version="1.0" encoding="utf-8"?> 
+  `;
+  try {
+    const result = await getMinimumTargetFrameworkFromPackagesConfig(noPackages);
+    t.pass('expected not to throw on missing packages element in the xml');
+    t.deepEqual(result, undefined, 'should return undefined on missing packages element');
+  } catch (error) {
+    t.fail('expected not to throw on missing packages element in the xml')
+  }
+
+  // give empty packages but don't expect to throw
+  const emptyPackages = `
+    <?xml version="1.0" encoding="utf-8"?>
+    <packages>
+    </packages>
+  `;
+  try {
+    const result = await getMinimumTargetFrameworkFromPackagesConfig(emptyPackages);
+    t.pass('expected not to throw on empty packages element in the xml');
+    t.deepEqual(result, undefined, 'should return undefined on empty packages element');
+  } catch (error) {
+    t.fail('expected not to throw on empty packages element in the xml');
+  }
+
+  // give a file with no targetFramework in the dependencies and expect undefined
+  const emptyTargetFramework = `
+    <?xml version="1.0" encoding="utf-8"?>
+    <packages>
+      <package id="jQuery" version="3.2.1" />
+    </packages>  
+  `;
+  try {
+    const shouldBeUndefined = await getMinimumTargetFrameworkFromPackagesConfig(emptyTargetFramework);
+    t.pass('expected not to throw on missing targetFramework');
+    t.equal(shouldBeUndefined, undefined, 'should return undefined on missing targetFramework');
+  } catch (error) {
+    t.fail('expected not to throw on missing targetFramework');
+  }
+});

--- a/test/parse-dotnet-cli.test.ts
+++ b/test/parse-dotnet-cli.test.ts
@@ -4,6 +4,9 @@ import * as plugin from '../lib/index';
 const projectPath = './test/stubs/dummy_project_2/';
 const manifestFile = 'obj/project.assets.json';
 
+const packagesConfigOnlyPath = './test/stubs/packages-config-only/';
+const packagesConfigOnlyManifestFile = 'packages.config';
+
 test('parse dotnet-cli project without frameworks field', async (t) => {
   try {
     await plugin.inspect(projectPath, manifestFile, {packagesFolder: projectPath + './_packages'});
@@ -11,4 +14,13 @@ test('parse dotnet-cli project without frameworks field', async (t) => {
   } catch(error) {
     t.equals(error.message, 'No frameworks were found in project.assets.json');
   }
+});
+
+test('parse dotnet-cli project with packages.config only', async (t) => {
+  const res = await plugin.inspect(packagesConfigOnlyPath, packagesConfigOnlyManifestFile);
+  t.equal(res.package.name, 'packages-config-only', 'expected packages-config-only name');
+  // expect the first found targetRuntime to be returned by the plugin
+  t.equal(res.plugin.targetRuntime, 'net452', 'expected net452 framework');
+  t.ok(res.package.dependencies.jQuery, 'jQuery should be found because specified');
+  t.ok(res.package.dependencies['Moment.js'], 'Moment.js should be found because specified');
 });

--- a/test/stubs/packages-config-only/packages.config
+++ b/test/stubs/packages-config-only/packages.config
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="jQuery" version="3.2.1" targetFramework="net461" />
+  <package id="Moment.js" version="2.20.1" targetFramework="net452" />
+</packages>


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Introduces `docker-deps-parser` to scan .NET Framework projects, and more specifically, looks for the `packages.config` file.
Currently you cannot use the CLI to scan anything other than .NET projects that have a `.csproj` file in their directory.

#### Where should the reviewer start?


#### How should this be manually tested?

`npm run test`, it shouldn't introduce regressions.

#### Any background context you want to provide?

Part of a support ticket request.

#### What are the relevant tickets?


#### Screenshots


#### Additional questions
