### PR TITLE
fix: support net4 as a target framework

### DIFF
--- a/lib/nuget-parser/framework.ts
+++ b/lib/nuget-parser/framework.ts
@@ -8,6 +8,16 @@ export function toReadableFramework(targetFramework: string): TargetFramework | 
     v: '.NETFramework',
   };
 
+  // HACK: this is an edge case and it's supported by NuGet design
+  // https://github.com/NuGet/Home/issues/1371
+  if (targetFramework === 'net4') {
+    return {
+      framework: typeMapping.net,
+      original: targetFramework,
+      version: '4',
+    };
+  }
+
   for (const type in typeMapping) {
     if (new RegExp(type + /\d.?\d(.?\d)?$/.source).test(targetFramework)) {
       return {
@@ -20,4 +30,3 @@ export function toReadableFramework(targetFramework: string): TargetFramework | 
 
   return undefined;
 }
-  

--- a/test/parse-dotnet-cli.test.ts
+++ b/test/parse-dotnet-cli.test.ts
@@ -6,6 +6,8 @@ const manifestFile = 'obj/project.assets.json';
 
 const packagesConfigOnlyPath = './test/stubs/packages-config-only/';
 const packagesConfigOnlyManifestFile = 'packages.config';
+const packageConfigWithNet4TFPath = './test/stubs/packages-config-net4/';
+const packageConfigWithNet4TFManifestFile = 'packages.config';
 
 test('parse dotnet-cli project without frameworks field', async (t) => {
   try {
@@ -23,4 +25,13 @@ test('parse dotnet-cli project with packages.config only', async (t) => {
   t.equal(res.plugin.targetRuntime, 'net452', 'expected net452 framework');
   t.ok(res.package.dependencies.jQuery, 'jQuery should be found because specified');
   t.ok(res.package.dependencies['Moment.js'], 'Moment.js should be found because specified');
+});
+
+test('parse dotnet-cli project with packages.config containing net4 as target framework', async (t) => {
+  const res = await plugin.inspect(packageConfigWithNet4TFPath, packageConfigWithNet4TFManifestFile);
+  t.equal(res.package.name, 'packages-config-net4', 'expected packages-config-net4 name');
+  // expect the first found targetRuntime to be returned by the plugin
+  t.equal(res.plugin.targetRuntime, 'net4', 'expected net4 framework');
+  t.ok(res.package.dependencies.jQuery, 'jQuery should be found because specified');
+  t.ok(res.package.dependencies.Unity, 'Unity should be found because specified');
 });

--- a/test/repositories-config-packages.test.ts
+++ b/test/repositories-config-packages.test.ts
@@ -11,6 +11,5 @@ const expectedTree = JSON.parse(fs.readFileSync(path.resolve(projectPath, 'expec
 
 test('packages contains many deps: only jquery', async (t) => {
   const result = await plugin.inspect(projectPath, manifestFile, {packagesFolder});
-  console.log(expectedTree);
   t.deepEqual(result, expectedTree, 'expects project data to be correct');
 });

--- a/test/stubs/packages-config-net4/packages.config
+++ b/test/stubs/packages-config-net4/packages.config
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Antlr" version="3.4.1.9004" targetFramework="net40" />
+  <package id="AutoMapper" version="2.1.267" targetFramework="net4" />
+  <package id="AWSSDK.Core" version="3.3.103.22" targetFramework="net40" />
+  <package id="AWSSDK.S3" version="3.3.104.10" targetFramework="net40" />
+  <package id="AWSSDK.SecretsManager" version="3.3.101.8" targetFramework="net40" />
+  <package id="AWSSDK.SecurityToken" version="3.3.102.7" targetFramework="net40" />
+  <package id="jQuery" version="1.9.1" targetFramework="net4" />
+  <package id="jQuery.UI.Combined" version="1.9.0" targetFramework="net4" />
+  <package id="jQuery.Validation" version="1.10.0" targetFramework="net4" />
+  <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net40" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="4.0.30506.0" targetFramework="net4" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="4.0.20710.0" targetFramework="net4" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="4.0.20710.0" targetFramework="net4" />
+  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net4" />
+  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net4" />
+  <package id="Microsoft.Net.Http" version="2.2.28" targetFramework="net4" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net4" />
+  <package id="Microsoft.Web.SessionState.SqlInMemory" version="1.0.2" targetFramework="net40" />
+  <package id="Moment.js" version="2.0.0" targetFramework="net4" />
+  <package id="Unity" version="2.1.505.2" targetFramework="net4" />
+  <package id="WebGrease" version="1.5.2" targetFramework="net40" />
+</packages>


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [X] Reviewed by Snyk internal team

#### What does this PR do?
Add a hack to handle `net4` target framework. 
It's a weird thing, but supported by Nuget Design. [NuGet.Home#1371](https://github.com/NuGet/Home/issues/1371)