### PR TITLE
feat: upgrade jszip

### DIFF
--- a/lib/nuget-parser/nuspec-parser.ts
+++ b/lib/nuget-parser/nuspec-parser.ts
@@ -21,7 +21,7 @@ export async function parseNuspec(dep, targetFramework) {
       const nuspecFiles = Object.keys(nuspecZipData.files).filter((file) => {
         return (path.extname(file) === '.nuspec');
       });
-      return nuspecZipData.files[nuspecFiles[0]].async('string');
+      return nuspecZipData.files[nuspecFiles[0]].async('text');
     })
     .then((nuspecContent) => {
       return new Promise((resolve, reject) => {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@snyk/lodash": "4.17.15-patch",
     "debug": "^4.1.1",
     "dotnet-deps-parser": "4.10.0",
-    "jszip": "3.3.0",
+    "jszip": "3.4.0",
     "snyk-paket-parser": "1.6.0",
     "tslib": "^1.11.2",
     "xml2js": "^0.4.17"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "pretty": true,
     "target": "es2017",
     "lib": [
+      "dom", // needed for a "bug" in the jszip typings (uses Blob)
       "es2017"
     ],
     "module": "commonjs",


### PR DESCRIPTION
They've made significant typing changes in this version, which we have to handle in two places.

Putting `dom` in `lib: []` is less horrible than casting away the types entirely, I believe. Elsewhere this version compiles fine, because `lib` defaults to containing `dom`.

`string` is equivalent to `text`, but `text` is the documented one.
