### PR TITLE
feat: fix for issue #75 - conflicting target framework monikers

### DIFF
--- a/lib/nuget-parser/dotnet-core-parser.ts
+++ b/lib/nuget-parser/dotnet-core-parser.ts
@@ -189,7 +189,10 @@ export async function parse(tree, manifest) {
   }
 
   // If a targetFramework was not found in the proj file, we will extract it from the lock file
-  if (!tree.meta.targetFramework) {
+  // OR
+  // If the targetFramework is undefined, extract it from the lock file
+  // Fix for https://github.com/snyk/snyk-nuget-plugin/issues/75
+  if (!tree.meta.targetFramework || manifest.project.frameworks[tree.meta.targetFramework] === undefined) {
     tree.meta.targetFramework = getFrameworkToRun(manifest);
   }
   const selectedFrameworkObj = manifest.project.frameworks[tree.meta.targetFramework];


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Fix for issue #75 - conflicting target frameworks between the project and project.assets.json files will result in an undefined object. If it's undefined, grab it from the lock file.

#### How should this be manually tested?

Specify different target framework monikers in the project and project.assets.json files (ex: v4.6.2 & net462)

#### What are the relevant tickets?

#75 
