### PR TITLE
feat: add optional project-name-prefix flag

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -61,5 +61,6 @@ export async function inspect(root, targetFile, options?) {
       targetFile,
       options.packagesFolder,
       manifestType,
-      options['assets-project-name']).then(createPackageTree);
+      options['assets-project-name'],
+      options['project-name-prefix']).then(createPackageTree);
 }

--- a/lib/nuget-parser/index.ts
+++ b/lib/nuget-parser/index.ts
@@ -36,12 +36,25 @@ function getPackagesFolder(packagesFolder, projectRootFolder) {
   return path.resolve(projectRootFolder, 'packages');
 }
 
+function getRootName(
+  root?: string,
+  projectRootFolder?: string,
+  projectNamePrefix?: string,
+): string {
+  const defaultRootName = path.basename(root || projectRootFolder || "");
+  if (projectNamePrefix) {
+    return projectNamePrefix + defaultRootName;
+  }
+  return defaultRootName;
+}
+
 export async function buildDepTreeFromFiles(
   root: string | undefined,
   targetFile: string | undefined,
   packagesFolderPath,
   manifestType,
-  useProjectNameFromAssetsFile) {
+  useProjectNameFromAssetsFile,
+  projectNamePrefix?: string ) {
   const safeRoot = root || '.';
   const safeTargetFile = targetFile || '.';
   const fileContentPath = path.resolve(safeRoot, safeTargetFile);
@@ -58,7 +71,11 @@ export async function buildDepTreeFromFiles(
   const tree = {
     dependencies: {},
     meta: {},
-    name: path.basename(root || projectRootFolder),
+    name: getRootName(
+      root,
+      projectRootFolder,
+      projectNamePrefix
+    ),
     packageFormatVersion: 'nuget:0.0.0',
     version: '0.0.0',
   };

--- a/test/parse-with-project-name-prefix.test.ts
+++ b/test/parse-with-project-name-prefix.test.ts
@@ -1,0 +1,35 @@
+import * as tap from "tap";
+const test = tap.test;
+import * as plugin from "../lib/index";
+
+const projects = {
+  csproj: {
+    projectPath: "test/stubs/target_framework/no_csproj",
+    manifestFile: "obj/project.assets.json",
+    defaultName: "no_csproj",
+  },
+  packagesConfig: {
+    projectPath: "test/stubs/packages-config-only",
+    manifestFile: "packages.config",
+    defaultName: "packages-config-only",
+  },
+};
+
+for (const project in projects) {
+  const proj = projects[project];
+  test(`inspect ${project} with project-name-prefix option`, async (t) => {
+    const res = await plugin.inspect(proj.projectPath, proj.manifestFile, {
+      "project-name-prefix": "custom-prefix/",
+    });
+    t.equal(
+      res.package.name,
+      `custom-prefix/${proj.defaultName}`,
+      "expected name to be prefixed with value passed in via options"
+    );
+  });
+
+  test(`inspect ${project} without project-name-prefix option`, async (t) => {
+    const res = await plugin.inspect(proj.projectPath, proj.manifestFile, {});
+    t.equal(res.package.name, proj.defaultName, "expected default name");
+  });
+}


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Adds optional `--project-name-prefix` flag to CLI for this plugin, which allows the user to pass in a string which is prepended on to the root name (e.g. `--project-name-prefix=my-prefix/` -> `my-prefix/packages.config`. This is intended to fix several instances we've seen where a user's manifest in one project is overwritten by a similarly-named one in another; this is because we use Node's path.basename for dep tree naming, which strips out everything but the name of the file itself.