### PR TITLE
fix: return early after fulfilling promise

### DIFF
--- a/lib/nuget-parser/csproj-parser.ts
+++ b/lib/nuget-parser/csproj-parser.ts
@@ -14,47 +14,50 @@ export async function getTargetFrameworksFromProjFile(
   return new Promise<TargetFramework | undefined>((resolve, reject) => {
     debug('Looking for your .csproj file in ' + rootDir);
     const csprojPath = findFile(rootDir, /.*\.csproj$/);
-    if (csprojPath) {
-      debug('Checking .net framework version in .csproj file ' + csprojPath);
-
-      const csprojContents = fs.readFileSync(csprojPath);
-
-      let frameworks: (TargetFramework | undefined)[] = [];
-      parseXML.parseString(csprojContents, (err, parsedCsprojContents) => {
-        if (err) {
-          reject(new FileNotProcessableError(err));
-        }
-        const versionLoc = parsedCsprojContents?.Project?.PropertyGroup?.[0];
-        const versions = []
-          .concat(
-            (
-              versionLoc?.TargetFrameworkVersion?.[0] ||
-              versionLoc?.TargetFramework?.[0] ||
-              versionLoc?.TargetFrameworks?.[0] ||
-              ''
-            ).split(';'),
-          )
-          .filter(Boolean);
-
-        if (versions.length < 1) {
-          debug(
-            'Could not find TargetFrameworkVersion/TargetFramework' +
-              '/TargetFrameworks defined in the Project.PropertyGroup field of ' +
-              'your .csproj file',
-          );
-        }
-        frameworks = versions.map(toReadableFramework).filter(Boolean);
-        if (versions.length > 1 && frameworks.length < 1) {
-          debug(
-            'Could not find valid/supported .NET version in csproj file located at' +
-              csprojPath,
-          );
-        }
-        resolve(frameworks[0]);
-      });
+    if (!csprojPath) {
+      debug('.csproj file not found in ' + rootDir + '.');
+      resolve(undefined);
+      return;
     }
-    debug('.csproj file not found in ' + rootDir + '.');
-    resolve();
+
+    debug('Checking .net framework version in .csproj file ' + csprojPath);
+
+    const csprojContents = fs.readFileSync(csprojPath);
+
+    let frameworks: (TargetFramework | undefined)[] = [];
+    parseXML.parseString(csprojContents, (err, parsedCsprojContents) => {
+      if (err) {
+        reject(new FileNotProcessableError(err));
+        return;
+      }
+      const versionLoc = parsedCsprojContents?.Project?.PropertyGroup?.[0];
+      const versions = []
+        .concat(
+          (
+            versionLoc?.TargetFrameworkVersion?.[0] ||
+            versionLoc?.TargetFramework?.[0] ||
+            versionLoc?.TargetFrameworks?.[0] ||
+            ''
+          ).split(';'),
+        )
+        .filter(Boolean);
+
+      if (versions.length < 1) {
+        debug(
+          'Could not find TargetFrameworkVersion/TargetFramework' +
+            '/TargetFrameworks defined in the Project.PropertyGroup field of ' +
+            'your .csproj file',
+        );
+      }
+      frameworks = versions.map(toReadableFramework).filter(Boolean);
+      if (versions.length > 1 && frameworks.length < 1) {
+        debug(
+          'Could not find valid/supported .NET version in csproj file located at' +
+            csprojPath,
+        );
+      }
+      resolve(frameworks[0]);
+    });
   });
 }
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Without early returns after a `resolve()` or `reject()`, while the promise will fulfil, the code below it will continue to execute. Some customers were seeing "file not found" in their debug logs despite it existing. That was confusing them (and us). This is probably why.

The diff here looks complicated on GitHub due to whitespace/indent changes. All I've done is switch the `if(file)` to `if(!file)` and added `return` after the first `resolve` and  the `reject`. The diff should look better locally.

![Screenshot 2021-04-15 at 16 32 37](https://user-images.githubusercontent.com/79453381/114896411-38837b80-9e08-11eb-81c2-d94645ce0a2f.png)