### PR TITLE
chore: ensure nuspec parsing won't fail with undefined error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ package-lock.json
 .nyc_output/
 # Diagnostic reports (https://nodejs.org/api/report.html) 
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+.idea
+.vscode

--- a/lib/nuget-parser/types.ts
+++ b/lib/nuget-parser/types.ts
@@ -1,5 +1,18 @@
+import { Dependency } from './dependency';
+
 export interface TargetFramework {
   framework: string;
   original: string;
   version: string;
+}
+
+export interface DependencyInfo {
+  name: string;
+  path: string;
+  version: string;
+}
+
+export interface DependencyTree {
+  name: string;
+  children: Dependency[];
 }

--- a/test/parseNuspec-no-dependencies.spec.ts
+++ b/test/parseNuspec-no-dependencies.spec.ts
@@ -1,0 +1,122 @@
+import { _parsedNuspec } from '../lib/nuget-parser/nuspec-parser';
+
+import * as fs from 'fs';
+
+import * as plugin from '../lib/index';
+
+
+JSON.parse(fs.readFileSync('./test/stubs/_2_project.json', 'utf-8'));
+
+const projects = {
+  csproj: {
+    projectPath: "./test/stubs/target_framework/no_csproj",
+    manifestFile: "obj/project.assets.json",
+    defaultName: "no_csproj",
+  },
+
+  packagesConfig: {
+    projectPath: "./test/stubs/packages-config-only",
+    manifestFile: "packages.config",
+    defaultName: "packages-config-only",
+  },
+};
+
+describe('parse-with-project-name-prefix', () => {
+  for (const project in projects) {
+    const proj = projects[project];
+    it(`inspect ${project} with project-name-prefix option`, async () => {
+      if(proj.defaultName === 'packages-config-only'){
+        console.log('foo');
+      }
+      const res = await plugin.inspect(proj.projectPath, proj.manifestFile, {
+        "project-name-prefix": "custom-prefix/",
+      });
+      expect(
+        res.package.name).toEqual(`custom-prefix/${proj.defaultName}`);
+    });
+  }
+});
+
+describe('parseNuSpec', () => {
+  const nuspecWithoutMetadataDependencies = '<?xml version="1.0"?>\n' +
+    '<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">\n' +
+    '  <metadata>\n' +
+    '    <id>jQuery</id>\n' +
+    '    <version>3.2.1</version>\n' +
+    '    <title>jQuery</title>\n' +
+    '    <authors>jQuery Foundation, Inc.</authors>\n' +
+    '    <owners>jQuery Foundation, Inc.</owners>\n' +
+    '    <licenseUrl>http://jquery.org/license</licenseUrl>\n' +
+    '    <projectUrl>http://jquery.com/</projectUrl>\n' +
+    '    <requireLicenseAcceptance>false</requireLicenseAcceptance>\n' +
+    '    <description>jQuery is a new kind of JavaScript Library.\n' +
+    '        jQuery is a fast and concise JavaScript Library that simplifies HTML document traversing, event handling, animating, and Ajax interactions for rapid web development. jQuery is designed to change the way that you write JavaScript.\n' +
+    '        NOTE: This package is maintained on behalf of the library owners by the NuGet Community Packages project at http://nugetpackages.codeplex.com/</description>\n' +
+    '    <language>en-US</language>\n' +
+    '    <tags>jQuery</tags>\n' +
+    '  </metadata>\n' +
+    '</package>'
+
+  const nuspecWithoutMetadata = '<?xml version="1.0"?>\n' +
+    '<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">\n' +
+    '</package>'
+
+  const nuspecWithMalformedTag = '<?xml version="1.0"?>\n' +
+    '<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">\n' +
+    '<metadata123>\n' +
+  '    <id>jQuery</id>\n' +
+  '    <version>3.2.1</version>\n' +
+  '    <title>jQuery</title>\n' +
+  '    <authors>jQuery Foundation, Inc.</authors>\n' +
+  '    <owners>jQuery Foundation, Inc.</owners>\n' +
+  '    <licenseUrl>http://jquery.org/license</licenseUrl>\n' +
+  '    <projectUrl>http://jquery.com/</projectUrl>\n' +
+  '    <requireLicenseAcceptance>false</requireLicenseAcceptance>\n' +
+  '    <description>jQuery is a new kind of JavaScript Library.\n' +
+  '        jQuery is a fast and concise JavaScript Library that simplifies HTML document traversing, event handling, animating, and Ajax interactions for rapid web development. jQuery is designed to change the way that you write JavaScript.\n' +
+  '        NOTE: This package is maintained on behalf of the library owners by the NuGet Community Packages project at http://nugetpackages.codeplex.com/</description>\n' +
+  '    <language>en-US</language>\n' +
+  '    <tags>jQuery</tags>\n' +
+  '  </metadata>\n' +
+    '</package>'
+
+  const nuspecWithNonArrayDependencies = '<?xml version="1.0"?>\n' +
+    '<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">\n' +
+    '  <metadata>\n' +
+    '    <id>jQuery</id>\n' +
+    '    <version>3.2.1</version>\n' +
+    '    <title>jQuery</title>\n' +
+    '    <authors>jQuery Foundation, Inc.</authors>\n' +
+    '    <dependencies>ABCD</dependencies>\n' +
+    '  </metadata>\n' +
+    '</package>'
+
+  it('should not throw an error when there are no dependencies in the metadata', async () => {
+    const parsedResult = await _parsedNuspec(nuspecWithoutMetadataDependencies, {
+      original: '',
+      framework: 'net',
+      version: '472'
+    }, 'dependencyName')
+    expect(parsedResult).toBeDefined();
+    expect(parsedResult.children).toBeDefined();
+    expect(parsedResult.name).toBeDefined();
+
+  });
+
+
+  it('should throw an error when there is no metadata', async () => {
+    await expect(_parsedNuspec(nuspecWithoutMetadata, {original: '', framework: 'net',
+      version: '472'},'dependencyName')).rejects.toThrow();
+  });
+
+  it('should throw an error when the nuspec contains malformed XML', async () => {
+    await expect(_parsedNuspec(nuspecWithMalformedTag, {original: '',framework: 'net',
+      version: '472'},'dependencyName')).rejects.toThrow();
+  });
+
+  it('should throw an error when the nuspec contains non-array dependencies tag', async () => {
+    await expect(_parsedNuspec(nuspecWithNonArrayDependencies, {original: '',framework: 'net',
+      version: '472'},'dependencyName')).rejects.toThrow();
+  });
+
+});


### PR DESCRIPTION
#### What does this PR do?
The current code does not check for when there is either not metadata or the metadata has no dependencies. We believe this is the reason for a customer getting the following error - TypeError: Cannot read property 'forEach' of undefined. This pr checks for both these cases and acts accordingly. 

#### How should this be manually tested?
Should be tested on a manifest where at least one dependency has no dependencies of it's own
