### PR TITLE
fix: Fixes an issue where snyk csproj parser crashes when propertyGroup is missing from project file

### DIFF
--- a/lib/nuget-parser/csproj-parser.ts
+++ b/lib/nuget-parser/csproj-parser.ts
@@ -31,7 +31,7 @@ export async function getTargetFrameworksFromProjFile(
         return;
       }
 
-      const parsedTargetFrameworks = parsedCsprojContents?.Project?.PropertyGroup?.reduce(
+      const parsedTargetFrameworks = (parsedCsprojContents?.Project?.PropertyGroup?.reduce(
         (targetFrameworks, propertyGroup) => {
           const targetFrameworkSource =
             propertyGroup?.TargetFrameworkVersion?.[0] ||
@@ -44,7 +44,7 @@ export async function getTargetFrameworksFromProjFile(
             .filter(Boolean);
         },
         [],
-      );
+      ) || []);
 
       if (parsedTargetFrameworks.length < 1) {
         debug(

--- a/test/csproj.spec.ts
+++ b/test/csproj.spec.ts
@@ -4,6 +4,10 @@ const targetFrameworkInNonFirstPropertyGroup =
   './test/stubs/target-framework-version-in-non-first-property-group';
 const multipleTargetFrameworksPath =
   './test/stubs/target_framework/csproj_multiple';
+const noTargetFrameworksPath =
+  './test/stubs/target_framework/no_target_framework';
+const noTargetFrameworksPath2 =
+  './test/stubs/target_framework/no_target_framework2';
 
 describe('getTargetFrameworksFromProjFile', () => {
   it('should parse target framework version even if it is in property group that is not first', async () => {
@@ -18,7 +22,7 @@ describe('getTargetFrameworksFromProjFile', () => {
     });
   });
 
-  it('should return first target framwork if multiple ones are available', async () => {
+  it('should return first target framework if multiple ones are available', async () => {
     const targetFramework = await getTargetFrameworksFromProjFile(
       multipleTargetFrameworksPath,
     );
@@ -28,5 +32,21 @@ describe('getTargetFrameworksFromProjFile', () => {
       original: 'netcoreapp2.0',
       version: '2.0',
     });
+  });
+
+  it('should not crash if target framework is not available in project file', async () => {
+    const targetFramework = await getTargetFrameworksFromProjFile(
+      noTargetFrameworksPath,
+    );
+
+    expect(targetFramework).toBeUndefined();
+  });
+
+  it('should not crash if target framework is not available in project file when property group exists', async () => {
+    const targetFramework = await getTargetFrameworksFromProjFile(
+      noTargetFrameworksPath2,
+    );
+
+    expect(targetFramework).toBeUndefined();
   });
 });

--- a/test/stubs/target_framework/no_target_framework2/no_target_framework2.csproj
+++ b/test/stubs/target_framework/no_target_framework2/no_target_framework2.csproj
@@ -1,0 +1,4 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <Import Project="$(RepositoryRoot)\LibraryProperties.props" />
+
+</Project>


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

This fixes an issue where snyk parser crashes cannot read "length" of undefined, it seems to me that logic was already handling the case where targetFrameworks returns empty array, but reading the property failed.

#### Where should the reviewer start?

Simple bug fix

#### How should this be manually tested?

Added unit test, but it can be manually tested as described in these Github issues: https://github.com/snyk/snyk-nuget-plugin/issues/103 https://github.com/snyk/snyk-nuget-plugin/issues/75

#### Any background context you want to provide?

-

#### What are the relevant tickets?

-

#### Screenshots

-

#### Additional questions

