### PR TITLE
fix: handle nuspec files with utf8 with BOM

### DIFF
--- a/lib/nuget-parser/csproj-parser.ts
+++ b/lib/nuget-parser/csproj-parser.ts
@@ -31,20 +31,21 @@ export async function getTargetFrameworksFromProjFile(
         return;
       }
 
-      const parsedTargetFrameworks = (parsedCsprojContents?.Project?.PropertyGroup?.reduce(
-        (targetFrameworks, propertyGroup) => {
-          const targetFrameworkSource =
-            propertyGroup?.TargetFrameworkVersion?.[0] ||
-            propertyGroup?.TargetFramework?.[0] ||
-            propertyGroup?.TargetFrameworks?.[0] ||
-            '';
+      const parsedTargetFrameworks =
+        parsedCsprojContents?.Project?.PropertyGroup?.reduce(
+          (targetFrameworks, propertyGroup) => {
+            const targetFrameworkSource =
+              propertyGroup?.TargetFrameworkVersion?.[0] ||
+              propertyGroup?.TargetFramework?.[0] ||
+              propertyGroup?.TargetFrameworks?.[0] ||
+              '';
 
-          return targetFrameworks
-            .concat(targetFrameworkSource.split(';'))
-            .filter(Boolean);
-        },
-        [],
-      ) || []);
+            return targetFrameworks
+              .concat(targetFrameworkSource.split(';'))
+              .filter(Boolean);
+          },
+          [],
+        ) || [];
 
       if (parsedTargetFrameworks.length < 1) {
         debug(

--- a/lib/nuget-parser/nuspec-parser.ts
+++ b/lib/nuget-parser/nuspec-parser.ts
@@ -82,7 +82,7 @@ export async function _parsedNuspec(
   targetFramework: TargetFramework,
   depName: string,
 ): Promise<DependencyTree> {
-  const parsedNuspec = await parseXML.parseStringPromise(nuspecContent);
+  const parsedNuspec = await parseXML.parseStringPromise(nuspecContent.trim());
   let ownDeps: Dependency[] = [];
 
   //note: this will throw if assertion fails

--- a/test/parse-utf8-bom.spec.ts
+++ b/test/parse-utf8-bom.spec.ts
@@ -1,0 +1,27 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import { _parsedNuspec } from '../lib/nuget-parser/nuspec-parser';
+
+it('should create dep tree for package encoded with utf8 with bom', async () => {
+  const nuspecContent = fs.readFileSync(
+    path.resolve('./test/stubs/utf8-bom-nuspec/NUnit.nuspec'),
+    'utf-8',
+  );
+  // prepending BOM unicode character
+  const nuspecContentWithBom = '\ufeff' + nuspecContent;
+
+  const depTree = await _parsedNuspec(
+    nuspecContentWithBom,
+    {
+      framework: '.NETFramework',
+      original: 'v4.6.1',
+      version: '4.6.1',
+    },
+    'NUnit',
+  );
+
+  expect(depTree).toEqual({
+    children: [],
+    name: 'NUnit',
+  });
+});

--- a/test/stubs/utf8-bom-nuspec/NUnit.nuspec
+++ b/test/stubs/utf8-bom-nuspec/NUnit.nuspec
@@ -1,0 +1,27 @@
+﻿﻿<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>NUnit</id>
+    <version>2.6.3</version>
+    <title>NUnit</title>
+    <authors>Charlie Poole</authors>
+    <owners>Charlie Poole</owners>
+    <licenseUrl>http://nunit.org/nuget/license.html</licenseUrl>
+    <projectUrl>http://nunit.org</projectUrl>
+    <iconUrl>http://nunit.org/nuget/nunit_32x32.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>NUnit features a fluent assert syntax, parameterized, generic and theory tests and is user-extensible. A number of runners, both from the NUnit project and by third parties, are able to execute NUnit tests.
+
+Version 2.6 is the seventh major release of this well-known and well-tested programming tool.
+
+This package includes only the framework assembly. You will need to install the NUnit.Runners package unless you are using a third-party runner.</description>
+    <summary>NUnit is a unit-testing framework for all .Net languages with a strong TDD focus.</summary>
+    <releaseNotes>Version 2.6 is the seventh major release of NUnit.
+
+Unlike earlier versions, this package includes only the framework assembly. You will need to install the NUnit.Runners package unless you are using a third-party runner.
+
+The nunit.mocks assembly is now provided by the NUnit.Mocks package. The pnunit.framework assembly is provided by the pNUnit package.</releaseNotes>
+    <language>en-US</language>
+    <tags>nunit test testing tdd framework fluent assert theory plugin addin</tags>
+  </metadata>
+</package>


### PR DESCRIPTION
Parsing nuspec when encoded in UTF-8 with BOM throws error `Non-whitespace before first tag` which is thrown by [xml2js](https://github.com/Leonidas-from-XIV/node-xml2js/issues/345) library. This library doesn't support scanning files with BOM character therefore we strip it. string.trim() function removes all whitespace characters including BOM