### PR TITLE
fix: add diagnostic code for edge-case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ package-lock.json
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 .idea
 .vscode
+.ionide/
+coverage/

--- a/lib/errors/invalid-folder-format-error.ts
+++ b/lib/errors/invalid-folder-format-error.ts
@@ -1,0 +1,9 @@
+export class InvalidFolderFormatError extends Error {
+  public code = 422;
+  public name = 'InvalidFolderFormat';
+
+  public constructor(...args) {
+    super(...args);
+    Error.captureStackTrace(this, InvalidFolderFormatError);
+  }
+}

--- a/test/parseNuspec-no-dependencies.spec.ts
+++ b/test/parseNuspec-no-dependencies.spec.ts
@@ -25,9 +25,6 @@ describe('parse-with-project-name-prefix', () => {
   for (const project in projects) {
     const proj = projects[project];
     it(`inspect ${project} with project-name-prefix option`, async () => {
-      if(proj.defaultName === 'packages-config-only'){
-        console.log('foo');
-      }
       const res = await plugin.inspect(proj.projectPath, proj.manifestFile, {
         "project-name-prefix": "custom-prefix/",
       });

--- a/test/unit.spec.ts
+++ b/test/unit.spec.ts
@@ -1,0 +1,21 @@
+import { fromFolderName } from '../lib/nuget-parser/dependency';
+import { InvalidFolderFormatError } from '../lib/errors/invalid-folder-format-error';
+
+describe('fromFolderName() method', () => {
+  it('should properly fail when parsing folder without expectedVersion', () => {
+    expect(() =>
+      fromFolderName('someLibraryNameWithoutexpectedVersion'),
+    ).toThrow(InvalidFolderFormatError);
+  });
+
+  //sanity check
+  it.each([
+    ['RestSharp.105.2.3', '105.2.3'],
+    ['FooBar.1.2', '1.2'],
+    ['FooBar1.2', '2'],
+  ])("should correctly parse '%s'", (folder, expectedVersion) => {
+    const result = fromFolderName(folder);
+    expect(result).toBeTruthy();
+    expect(result.version).toBe(expectedVersion);
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Add diagnostic code and more detailed logging for easier diagnostics of an edge-case


#### Any background context you want to provide?
For NuGet cache for .Net frameworks, the folder name should be in format of [package name].[semantic version]  
Since it is pretty much framework internals, the code assumes it is always the case. This change adds some diagnostics & logging for cases where the NuGet cache folders do not adhere to such format
