### PR TITLE
fix: lodash is not a dev dep, but used in prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "jszip": "3.8.0",
     "snyk-paket-parser": "1.6.0",
     "tslib": "^1.11.2",
-    "xml2js": "^0.5.0"
+    "xml2js": "^0.5.0",
+    "lodash": "^4.17.5"
   },
   "devDependencies": {
     "@types/jest": "^27.0.2",
@@ -52,7 +53,6 @@
     "prettier": "^1.19.1",
     "tap": "^14.10.7",
     "ts-jest": "^26.4.0",
-    "typescript": "~4.7.3",
-    "lodash": "^4.17.5"
+    "typescript": "~4.7.3"
   }
 }


### PR DESCRIPTION
If you install this a place where `lodash` is not already installed you'll get errors.