### PR TITLE
feat: [OSM-571] replacing exec with a subprocess with support for Snyk CLI V2

### DIFF
--- a/lib/nuget-parser/cli/subprocess.ts
+++ b/lib/nuget-parser/cli/subprocess.ts
@@ -1,0 +1,68 @@
+import { spawn, SpawnOptions } from 'child_process';
+
+interface ProcessOptions {
+  cwd?: string;
+  env?: { [name: string]: string };
+}
+
+export interface ExecResult {
+  stdout: string;
+  stderr: string;
+}
+
+function makeSpawnOptions(options?: ProcessOptions) {
+  const spawnOptions: SpawnOptions = {
+    shell: false,
+    env: { ...process.env },
+  };
+  if (options?.cwd) {
+    spawnOptions.cwd = options.cwd;
+  }
+
+  if (options?.env) {
+    spawnOptions.env = { ...spawnOptions.env, ...options.env };
+  } else {
+    spawnOptions.env = { ...spawnOptions.env };
+  }
+
+  // Before spawning an external process, we check if we need to
+  // restore the system proxy configuration, which overrides the CLI internal proxy configuration.
+  if (process.env.SNYK_SYSTEM_HTTP_PROXY !== undefined) {
+    spawnOptions.env.HTTP_PROXY = process.env.SNYK_SYSTEM_HTTP_PROXY;
+  }
+  if (process.env.SNYK_SYSTEM_HTTPS_PROXY !== undefined) {
+    spawnOptions.env.HTTPS_PROXY = process.env.SNYK_SYSTEM_HTTPS_PROXY;
+  }
+  if (process.env.SNYK_SYSTEM_NO_PROXY !== undefined) {
+    spawnOptions.env.NO_PROXY = process.env.SNYK_SYSTEM_NO_PROXY;
+  }
+
+  return spawnOptions;
+}
+
+export function execute(
+  command: string,
+  args: string[],
+  options?: ProcessOptions,
+): Promise<ExecResult> {
+  const spawnOptions = makeSpawnOptions(options);
+  return new Promise((resolve, reject) => {
+    let stdout = '';
+    let stderr = '';
+
+    const proc = spawn(command, args, spawnOptions);
+    proc.stdout?.on('data', (data) => {
+      stdout = stdout + data;
+    });
+    proc.stderr?.on('data', (data) => {
+      stderr = stderr + data;
+    });
+
+    proc.on('close', (code) => {
+      if (code !== 0) {
+        return reject({ stdout, stderr });
+      }
+      resolve({ stdout, stderr });
+    });
+  });
+}


### PR DESCRIPTION
Same as https://github.com/snyk/snyk-go-plugin/pull/103 and https://github.com/snyk/snyk-swiftpm-plugin/pull/29

> There is a bigger architectural change in the Extensible CLI.

> The Extensible CLI spawns a network proxy (which intercepts the SSL connections) and channels all the traffic from the legacy CLI through that internal proxy. The Intention is to add support for different features like Kerberos Proxy Authentication, OS CA stores, OAuth … through the Golang based Extensible CLI to the legacy CLI. This happens by setting the proxy settings when calling the legacy CLI from within the Extensible CLI. When the legacy CLI now calls an external tool, this tool would also try to communicate through the internal proxy. Since the internal proxy intercepts SSL connections, it uses a self-signed CA cert, which is known to the legacy CLI but not the external tools it calls.
There are actually different solutions.

> Using the solution we applied in the [snyk-go-plugin](https://github.com/snyk/snyk-go-plugin/blob/master/lib/sub-process.ts#L22) and others, which restores the proxy settings to whatever the user specified.

> Telling the external tool to accept the temporary certificate file used by the internal proxy.