### PR TITLE
feat: [OSM-592] Add support multiple target frameworks for v2 logic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,10 +35,12 @@ commands:
     steps:
       - run:
           name: Install correct version of Node
-          command: nvm install << parameters.node_version >>
+          command: |
+            nvm install << parameters.node_version >>
       - run:
           name: Use correct version of Node
           command: |
+            set -e
             nvm list
             nvm use << parameters.node_version >>
 

--- a/lib/nuget-parser/cli/dotnet.ts
+++ b/lib/nuget-parser/cli/dotnet.ts
@@ -54,11 +54,21 @@ export async function restore(projectPath: string): Promise<void> {
   return;
 }
 
-export async function publish(projectPath: string): Promise<string> {
+export async function publish(
+  projectPath: string,
+  targetFramework?: string,
+): Promise<string> {
   const command = 'dotnet';
   const args = ['publish', '--nologo'];
   // Self-contained: Create all required .dlls for version investigation, don't rely on the environment.
   args.push('--sc');
+
+  // If your .csproj file contains multiple <TargetFramework> references, you need to supply which one you want to publish.
+  if (targetFramework) {
+    args.push('--framework');
+    args.push(targetFramework);
+  }
+
   // The path that contains either some form of project file, or a .sln one.
   // See: https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-publish#arguments
   args.push(projectPath);

--- a/lib/nuget-parser/index.ts
+++ b/lib/nuget-parser/index.ts
@@ -122,7 +122,10 @@ export async function buildDepGraphFromFiles(
     await dotnet.validate();
 
     // Run `dotnet publish` to create a self-contained publishable binary with included .dlls for assembly version inspection.
-    const publishDir = await dotnet.publish(projectRootFolder);
+    const publishDir = await dotnet.publish(
+      projectRootFolder,
+      targetFramework.original,
+    );
     // Then inspect the dependency graph for the runtimepackage's assembly versions.
     const depsFile = path.resolve(
       publishDir,

--- a/lib/nuget-parser/index.ts
+++ b/lib/nuget-parser/index.ts
@@ -78,9 +78,8 @@ export async function buildDepGraphFromFiles(
   const fileContentPath = path.resolve(safeRoot, safeTargetFile);
   const fileContent = getFileContents(fileContentPath);
   const projectRootFolder = path.resolve(fileContentPath, '../../');
-  const targetFramework = await csProjParser.getTargetFrameworksFromProjFile(
-    projectRootFolder,
-  );
+  const targetFramework =
+    await csProjParser.getTargetFrameworksFromProjFile(projectRootFolder);
 
   if (!targetFramework) {
     throw new FileNotProcessableError(
@@ -172,9 +171,8 @@ export async function buildDepTreeFromFiles(
   let targetFramework: TargetFramework | undefined;
   try {
     if (manifestType === ManifestType.DOTNET_CORE) {
-      targetFramework = await csProjParser.getTargetFrameworksFromProjFile(
-        projectRootFolder,
-      );
+      targetFramework =
+        await csProjParser.getTargetFrameworksFromProjFile(projectRootFolder);
     } else {
       // .csproj is in the same directory as packages.config or project.json
       const fileContentParentDirectory = path.resolve(fileContentPath, '../');

--- a/package.json
+++ b/package.json
@@ -48,11 +48,11 @@
   "devDependencies": {
     "@types/jest": "^29.5.3",
     "@types/node": "^20.4.5",
-    "@typescript-eslint/eslint-plugin": "^6.2.1",
-    "@typescript-eslint/parser": "^6.2.1",
-    "eslint": "^8.46.0",
+    "@typescript-eslint/eslint-plugin": "^6.5.0",
+    "@typescript-eslint/parser": "^6.5.0",
+    "eslint": "^8.48.0",
     "jest": "^29.6.2",
-    "prettier": "^3.0.0",
+    "prettier": "^3.0.3",
     "ts-jest": "^29.1.1",
     "typescript": "^5.1.6"
   }

--- a/test/cli/dotnet.spec.ts
+++ b/test/cli/dotnet.spec.ts
@@ -4,8 +4,14 @@ import * as tempFixture from '../helpers/temp-fixture';
 import * as fs from 'fs';
 
 describe('when running the dotnet cli command', () => {
-  let tempDir: string;
-  beforeAll(() => {
+  const projectDirs: Record<string, string> = {};
+  beforeAll(() => {});
+
+  afterAll(() => {
+    tempFixture.tearDown(Object.values(projectDirs));
+  });
+
+  it('publishes a dependency file correctly to the published folder', async () => {
     const fixtures: tempFixture.File[] = [
       {
         name: 'program.cs',
@@ -36,16 +42,51 @@ class TestFixture {
 `,
       },
     ];
-    tempDir = tempFixture.setup(fixtures);
-  });
+    projectDirs['runtimeDepsDiffer'] = tempFixture.setup(fixtures);
 
-  afterAll(() => {
-    tempFixture.tearDown(tempDir);
-  });
-
-  it('publishes a dependency file correctly to the published folder', async () => {
-    const publishDir = await dotnet.publish(tempDir);
+    const publishDir = await dotnet.publish(projectDirs['runtimeDepsDiffer']);
     const contents = fs.readdirSync(publishDir);
     expect(contents).toContain('dotnet_6.deps.json');
+  });
+
+  it('publishes a dependency file correctly to the published folder that has multiple target frameworks', async () => {
+    const fixtures: tempFixture.File[] = [
+      {
+        name: 'program.cs',
+        contents: `
+using System;
+class TestFixture {
+    static public void Main(String[] args)
+    {
+      var client = new System.Net.Http.HttpClient();
+      Console.WriteLine("Hello, World!");
+    }
+}
+`,
+      },
+      {
+        name: 'dotnet_6_and_7.csproj',
+        contents: `
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NSubstitute" Version="4.3.0"/>
+  </ItemGroup>
+</Project>
+`,
+      },
+    ];
+    projectDirs['multipleTargetFrameworks'] = tempFixture.setup(fixtures);
+
+    const publishDir = await dotnet.publish(
+      projectDirs['multipleTargetFrameworks'],
+      'net7.0',
+    );
+    const contents = fs.readdirSync(publishDir);
+    expect(contents).toContain('dotnet_6_and_7.deps.json');
   });
 });

--- a/test/dep-graph.spec.ts
+++ b/test/dep-graph.spec.ts
@@ -6,6 +6,8 @@ import * as tempFixture from './helpers/temp-fixture';
 import * as dotnet from '../lib/nuget-parser/cli/dotnet';
 
 describe('when generating a dependency graph', () => {
+  const projectDirs: Record<string, string> = {};
+
   let tempDir: string;
   beforeEach(async () => {
     const fixtures: tempFixture.File[] = [
@@ -43,7 +45,7 @@ class TestFixture {
   });
 
   afterEach(() => {
-    tempFixture.tearDown(tempDir);
+    tempFixture.tearDown(Object.values(projectDirs));
   });
 
   it('generates a correct dependency graph compared to the existing depTree logic', async () => {

--- a/test/helpers/temp-fixture.ts
+++ b/test/helpers/temp-fixture.ts
@@ -24,16 +24,18 @@ export function setup(files: File[]): string {
   return tempDir;
 }
 
-export function tearDown(dir: string) {
-  if (!dir) {
-    // No tempDir to tear down. Assuming the test failed somewhere.
-    // Jest won't throw an error anyway if the operation fails.
-    return;
-  }
+export function tearDown(dirs: string[]) {
+  for (const dir of dirs) {
+    if (!dir) {
+      // No tempDir to tear down. Assuming the test failed somewhere.
+      // Jest won't throw an error anyway if the operation fails.
+      return;
+    }
 
-  try {
-    fs.rmSync(dir, { recursive: true });
-  } catch (error: unknown) {
-    // Ignore it, test was tearing down anyway, and it seems Windows boxes especially don't like this.
+    try {
+      fs.rmSync(dir, { recursive: true });
+    } catch (error: unknown) {
+      // Ignore it, test was tearing down anyway, and it seems Windows boxes especially don't like this.
+    }
   }
 }

--- a/test/parsers/parse-packages-config.spec.ts
+++ b/test/parsers/parse-packages-config.spec.ts
@@ -176,9 +176,8 @@ describe('when calling getMinimumTargetFramework', () => {
 <package id="jQuery" version="3.2.1" />
 </packages>`,
   ])('should NOT throw', async (content) => {
-    const result = await packagesConfigParser.getMinimumTargetFramework(
-      content,
-    );
+    const result =
+      await packagesConfigParser.getMinimumTargetFramework(content);
     await expect(result).toBeUndefined();
   });
 });

--- a/test/runtime-assembly.spec.ts
+++ b/test/runtime-assembly.spec.ts
@@ -130,7 +130,7 @@ describe('when parsing runtime assembly', () => {
       expect(runtimeAssemblies).toMatchObject(expected);
 
       // Try your best to clean up. Avoiding the `afterEach` to not have too many global variables.
-      tempFixture.tearDown(tempDir);
+      tempFixture.tearDown([tempDir]);
     },
   );
 });


### PR DESCRIPTION
#### What does this PR do?

Scanning projects that targets multiple frameworks was not currently supported, as supplying something like

```xml
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFrameworks>net6.0;net7.0</TargetFrameworks> <----
    <RuntimeIdentifier>osx-x64</RuntimeIdentifier>
  </PropertyGroup>

  <ItemGroup>
    <PackageReference Include="NSubstitute" Version="4.3.0" />
  </ItemGroup>
</Project>
```

Would, rightfully, result in something like:

```bash
error NETSDK1129: The 'Publish' target is not supported without specifying a target framework. The current project targets multiple frameworks, you must specify the framework for the published application.
```

So we've updated the logic to handle this case.