### PR TITLE
feat: [OSM-347] Preparing logic for handling of multiple target frameworks

### DIFF
--- a/lib/nuget-parser/index.ts
+++ b/lib/nuget-parser/index.ts
@@ -78,10 +78,10 @@ export async function buildDepGraphFromFiles(
   const fileContentPath = path.resolve(safeRoot, safeTargetFile);
   const fileContent = getFileContents(fileContentPath);
   const projectRootFolder = path.resolve(fileContentPath, '../../');
-  const targetFramework =
+  const targetFrameworks =
     csProjParser.getTargetFrameworksFromProjFile(projectRootFolder);
 
-  if (!targetFramework) {
+  if (targetFrameworks.length <= 0) {
     throw new FileNotProcessableError(
       `unable to detect a target framework in ${projectRootFolder}, a valid one is needed to continue down this path.`,
     );
@@ -109,6 +109,9 @@ export async function buildDepGraphFromFiles(
       );
     }
   }
+
+  // TODO: OSM-347 - use more than just the first one we find
+  const targetFramework = targetFrameworks[0];
 
   let assemblyVersions: AssemblyVersions = {};
   if (useRuntimeDependencies) {
@@ -171,24 +174,27 @@ export async function buildDepTreeFromFiles(
     version: '0.0.0',
   };
 
-  let targetFramework: TargetFramework | undefined;
+  let targetFrameworks: TargetFramework[];
   try {
     if (manifestType === ManifestType.DOTNET_CORE) {
-      targetFramework =
+      targetFrameworks =
         csProjParser.getTargetFrameworksFromProjFile(projectRootFolder);
     } else {
       // .csproj is in the same directory as packages.config or project.json
       const fileContentParentDirectory = path.resolve(fileContentPath, '../');
-      targetFramework = csProjParser.getTargetFrameworksFromProjFile(
+      targetFrameworks = csProjParser.getTargetFrameworksFromProjFile(
         fileContentParentDirectory,
       );
 
       // finally, for the .NETFramework project, try to assume the framework using dotnet-deps-parser
-      if (!targetFramework) {
+      if (targetFrameworks.length <= 0) {
         // currently only process packages.config files
         if (manifestType === ManifestType.PACKAGES_CONFIG) {
-          targetFramework =
+          const minimumTargetFramework =
             await packagesConfigParser.getMinimumTargetFramework(fileContent);
+          if (minimumTargetFramework) {
+            targetFrameworks = [minimumTargetFramework];
+          }
         }
       }
     }
@@ -196,8 +202,11 @@ export async function buildDepTreeFromFiles(
     return Promise.reject(error);
   }
 
+  // TODO: OSM-347 - use more than just the first one we find
+  const targetFramework =
+    targetFrameworks.length > 0 ? targetFrameworks[0].original : undefined;
   tree.meta = {
-    targetFramework: targetFramework ? targetFramework.original : undefined, // TODO implement for more than one TF
+    targetFramework: targetFramework,
   };
 
   const parser = PARSERS[manifestType];

--- a/lib/nuget-parser/index.ts
+++ b/lib/nuget-parser/index.ts
@@ -79,7 +79,7 @@ export async function buildDepGraphFromFiles(
   const fileContent = getFileContents(fileContentPath);
   const projectRootFolder = path.resolve(fileContentPath, '../../');
   const targetFramework =
-    await csProjParser.getTargetFrameworksFromProjFile(projectRootFolder);
+    csProjParser.getTargetFrameworksFromProjFile(projectRootFolder);
 
   if (!targetFramework) {
     throw new FileNotProcessableError(
@@ -175,11 +175,11 @@ export async function buildDepTreeFromFiles(
   try {
     if (manifestType === ManifestType.DOTNET_CORE) {
       targetFramework =
-        await csProjParser.getTargetFrameworksFromProjFile(projectRootFolder);
+        csProjParser.getTargetFrameworksFromProjFile(projectRootFolder);
     } else {
       // .csproj is in the same directory as packages.config or project.json
       const fileContentParentDirectory = path.resolve(fileContentPath, '../');
-      targetFramework = await csProjParser.getTargetFrameworksFromProjFile(
+      targetFramework = csProjParser.getTargetFrameworksFromProjFile(
         fileContentParentDirectory,
       );
 

--- a/lib/nuget-parser/parsers/dotnet-core-parser.ts
+++ b/lib/nuget-parser/parsers/dotnet-core-parser.ts
@@ -209,7 +209,7 @@ function validateManifest(manifest) {
   }
 }
 
-export async function parse(tree, manifest) {
+export function parse(tree, manifest) {
   debug('Trying to parse dot-net-cli manifest');
 
   validateManifest(manifest);

--- a/test/parsers/csproj.spec.ts
+++ b/test/parsers/csproj.spec.ts
@@ -4,56 +4,49 @@ import * as plugin from '../../lib';
 
 describe('parse .csproj', () => {
   describe('getTargetFrameworksFromProjFile', () => {
-    it('should parse target framework version even if it is in property group that is not first', async () => {
-      const targetFrameworkInNonFirstPropertyGroup =
-        './test/fixtures/target-framework/target-framework-version-in-non-first-property-group';
-
-      const targetFramework = getTargetFrameworksFromProjFile(
-        targetFrameworkInNonFirstPropertyGroup,
-      );
-
-      expect(targetFramework).toMatchObject({
-        framework: '.NETFramework',
-        original: 'v4.7.2',
-        version: '4.7.2',
-      });
-    });
-
-    it('should return first target framework if multiple target frameworks are available', async () => {
-      const multipleTargetFrameworksPath =
-        './test/fixtures/target-framework/csproj-multiple';
-
-      const targetFramework = getTargetFrameworksFromProjFile(
-        multipleTargetFrameworksPath,
-      );
-
-      expect(targetFramework).toMatchObject({
-        framework: '.NETCore',
-        original: 'netcoreapp2.0',
-        version: '2.0',
-      });
-    });
-
-    it('should not crash if target framework is not available in project file', async () => {
-      const noTargetFrameworksPath =
-        './test/fixtures/target-framework/no-target-framework';
-
-      const targetFramework = getTargetFrameworksFromProjFile(
-        noTargetFrameworksPath,
-      );
-
-      expect(targetFramework).toBeUndefined();
-    });
-
-    it('should not crash if target framework is not available in project file when property group exists', async () => {
-      const noTargetFrameworksPath2 =
-        './test/fixtures/target-framework/no-target-framework2';
-
-      const targetFramework = getTargetFrameworksFromProjFile(
-        noTargetFrameworksPath2,
-      );
-
-      expect(targetFramework).toBeUndefined();
+    it.each([
+      {
+        description: 'it is in property group that is not first',
+        fixture:
+          './test/fixtures/target-framework/target-framework-version-in-non-first-property-group',
+        expected: [
+          {
+            framework: '.NETFramework',
+            original: 'v4.7.2',
+            version: '4.7.2',
+          },
+        ],
+      },
+      {
+        description: 'multiple target frameworks are available',
+        fixture: './test/fixtures/target-framework/csproj-multiple',
+        expected: [
+          {
+            framework: '.NETCore',
+            original: 'netcoreapp2.0',
+            version: '2.0',
+          },
+          {
+            framework: '.NETFramework',
+            original: 'net462',
+            version: '462',
+          },
+        ],
+      },
+      {
+        description: 'target framework is not available in project file',
+        fixture: './test/fixtures/target-framework/no-target-framework',
+        expected: [],
+      },
+      {
+        description:
+          'target framework is not available in project file when property group exists',
+        fixture: './test/fixtures/target-framework/no-target-framework2',
+        expected: [],
+      },
+    ])('should parse if $description', ({ fixture, expected }) => {
+      const targetFrameworks = getTargetFrameworksFromProjFile(fixture);
+      expect(targetFrameworks).toMatchObject(expected);
     });
   });
 

--- a/test/parsers/csproj.spec.ts
+++ b/test/parsers/csproj.spec.ts
@@ -8,7 +8,7 @@ describe('parse .csproj', () => {
       const targetFrameworkInNonFirstPropertyGroup =
         './test/fixtures/target-framework/target-framework-version-in-non-first-property-group';
 
-      const targetFramework = await getTargetFrameworksFromProjFile(
+      const targetFramework = getTargetFrameworksFromProjFile(
         targetFrameworkInNonFirstPropertyGroup,
       );
 
@@ -23,7 +23,7 @@ describe('parse .csproj', () => {
       const multipleTargetFrameworksPath =
         './test/fixtures/target-framework/csproj-multiple';
 
-      const targetFramework = await getTargetFrameworksFromProjFile(
+      const targetFramework = getTargetFrameworksFromProjFile(
         multipleTargetFrameworksPath,
       );
 
@@ -38,7 +38,7 @@ describe('parse .csproj', () => {
       const noTargetFrameworksPath =
         './test/fixtures/target-framework/no-target-framework';
 
-      const targetFramework = await getTargetFrameworksFromProjFile(
+      const targetFramework = getTargetFrameworksFromProjFile(
         noTargetFrameworksPath,
       );
 
@@ -49,7 +49,7 @@ describe('parse .csproj', () => {
       const noTargetFrameworksPath2 =
         './test/fixtures/target-framework/no-target-framework2';
 
-      const targetFramework = await getTargetFrameworksFromProjFile(
+      const targetFramework = getTargetFrameworksFromProjFile(
         noTargetFrameworksPath2,
       );
 

--- a/test/scalability/generate-huge-project-assets-json.spec.ts
+++ b/test/scalability/generate-huge-project-assets-json.spec.ts
@@ -229,7 +229,7 @@ describe('parse large dependency tree', () => {
       createDepTreeRecursive(`${key}/1.0.0`, manifest.targets, remainingLevel);
     });
 
-    const result = await parse(tree, manifest);
+    const result = parse(tree, manifest);
 
     expect(Object.keys(result.dependencies.jquery.dependencies).length).toBe(
       rootDepNum,


### PR DESCRIPTION
The current implementation was very hard-linked to the fact that we can only handle one `<TargetFramework>`. Even to the extend that the function called `getTargetFramework____s____FromProjFile` only returned a single target, and all logic everywhere just expected that.

This PR loosens that coupling a bit, and also tries to get away from that "either value or undefined" logic that permeates some parts of this code. I prefer a better practice where we return one type or an error.