### PR TITLE
feat: [OSM-347] Return multiple results part 2: Removing stuff we never used

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -93,14 +93,11 @@ This should be considered experimental and not relied upon for production use.
 Please report issues with this beta feature by submitting a support ticket, and attach the output of running this command
 with the debug (-d) flag at \x1b[4mhttps://support.snyk.io/hc/en-us/requests/new\x1b[0m.`);
 
-    // TODO: Replaced by a CLI argument when project is stabilized
-    const useRuntimeDependencies = true;
     const result = await nugetParser.buildDepGraphFromFiles(
       root,
       targetFile,
       manifestType,
       options['assets-project-name'],
-      useRuntimeDependencies,
       options['project-name-prefix'],
       options['target-framework'],
     );

--- a/lib/nuget-parser/parsers/dotnet-core-v2-parser.ts
+++ b/lib/nuget-parser/parsers/dotnet-core-v2-parser.ts
@@ -28,7 +28,7 @@ function recursivelyPopulateNodes(
   depGraphBuilder: DepGraphBuilder,
   targetDeps: Record<string, DotnetPackage>,
   node: DotnetPackage,
-  runtimeAssembly?: AssemblyVersions,
+  runtimeAssembly: AssemblyVersions,
   visited?: Set<string>,
 ) {
   const parentId =
@@ -47,16 +47,14 @@ function recursivelyPopulateNodes(
 
     const childId = `${childNode.name}@${childNode.version}`;
 
-    // If we've supplied runtime assembly versions for self-contained dlls, overwrite the dependency version
+    // If we're looking at a  runtime assembly version for self-contained dlls, overwrite the dependency version
     // we've found in the graph with those from the runtime assembly, as they take precedence.
     let assemblyVersion = version;
-    if (runtimeAssembly) {
-      // The RuntimeAssembly type contains the name with a .dll suffix, as this is how .NET represents them in the
-      // dependency file. This must be stripped in order to match the elements during depGraph construction.
-      const dll = `${name}.dll`;
-      if (dll in runtimeAssembly) {
-        assemblyVersion = runtimeAssembly[dll];
-      }
+    // The RuntimeAssembly type contains the name with a .dll suffix, as this is how .NET represents them in the
+    // dependency file. This must be stripped in order to match the elements during depGraph construction.
+    const dll = `${name}.dll`;
+    if (dll in runtimeAssembly) {
+      assemblyVersion = runtimeAssembly[dll];
     }
 
     if (localVisited.has(childId)) {
@@ -92,7 +90,7 @@ function recursivelyPopulateNodes(
 function buildGraph(
   projectName: string,
   projectAssets: ProjectAssets,
-  runtimeAssembly?: AssemblyVersions,
+  runtimeAssembly: AssemblyVersions,
 ): depGraphLib.DepGraph {
   const depGraphBuilder = new DepGraphBuilder(
     { name: 'nuget' },
@@ -178,15 +176,10 @@ function buildGraph(
 export function parse(
   projectName: string,
   projectAssets: ProjectAssets,
-  runtimeAssembly?: AssemblyVersions,
+  runtimeAssembly: AssemblyVersions,
 ): depGraphLib.DepGraph {
   debug('Trying to parse .net core manifest with v2 depGraph builder');
 
-  let result;
-  if (!runtimeAssembly) {
-    result = buildGraph(projectName, projectAssets);
-  } else {
-    result = buildGraph(projectName, projectAssets, runtimeAssembly);
-  }
+  const result = buildGraph(projectName, projectAssets, runtimeAssembly);
   return result;
 }

--- a/test/dep-graph.spec.ts
+++ b/test/dep-graph.spec.ts
@@ -66,8 +66,7 @@ class TestFixture {
       tempDir,
       'obj/project.assets.json',
       ManifestType.DOTNET_CORE,
-      false,
-      false,
+      false
     );
     expect(result.dependencyGraph).toBeDefined();
     const depGraph = result.dependencyGraph;

--- a/test/dep-graph.spec.ts
+++ b/test/dep-graph.spec.ts
@@ -33,7 +33,7 @@ class TestFixture {
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NSubstitute" Version="4.3.0"/>
+    <PackageReference Include="NSubstitute" Version="4.3.0" />
   </ItemGroup>
 </Project>
 `,
@@ -49,6 +49,7 @@ class TestFixture {
   });
 
   it('generates a correct dependency graph compared to the existing depTree logic', async () => {
+    // First generate the graph normally as we did before the new functionality, with depTrees and no runtime support.
     const depTree = await nugetParser.buildDepTreeFromFiles(
       tempDir,
       'obj/project.assets.json',
@@ -57,27 +58,45 @@ class TestFixture {
       false,
     );
     expect(depTree).toBeDefined();
-    const depTreeConverted = await depGraphLib.legacy.depTreeToGraph(
-      depTree,
-      'nuget',
-    );
+    const baseline = await depGraphLib.legacy.depTreeToGraph(depTree, 'nuget');
 
-    const result = await nugetParser.buildDepGraphFromFiles(
+    // Then do the same with the new functionality and validate the graph looks the same,
+    // only with newer versions for the runtime-specific dependencies. The rest should be identical.
+    const withRuntimeDeps = await nugetParser.buildDepGraphFromFiles(
       tempDir,
       'obj/project.assets.json',
       ManifestType.DOTNET_CORE,
-      false
+      false,
     );
-    expect(result.dependencyGraph).toBeDefined();
-    const depGraph = result.dependencyGraph;
+    expect(withRuntimeDeps.dependencyGraph).toBeDefined();
 
+    // Assert that the existing logic shows an older version of a runtime dependency:
+    expect(baseline).toBeDefined();
+    let pkg: depGraphLib.Pkg = {
+      name: 'System.Net.Http',
+      version: '4.3.0',
+    };
+    expect(baseline.getPkgs()).toContainEqual(pkg);
+    const baselinePathsToRoot = baseline
+      .pkgPathsToRoot(pkg)
+      .map((inner) => inner.map(({ name }) => ({ name })));
+
+    // Assert that with runtime deps it correctly reflects the net6.0 runtime version of the same package:
+    expect(withRuntimeDeps.dependencyGraph).toBeDefined();
+    pkg = {
+      name: 'System.Net.Http',
+      version: '6.0.0',
+    };
+    expect(withRuntimeDeps.dependencyGraph.getPkgs()).toContainEqual(pkg);
+    const withRuntimeDepsPathsToRoot = withRuntimeDeps.dependencyGraph
+      .pkgPathsToRoot(pkg)
+      .map((inner) => inner.map(({ name }) => ({ name })));
+
+    // Assert that no construction of the depGraph otherwise was destroyed in the process.
     // The depTree will not be completely identical to the depGraph, so we cannot compare one-to-one. For instance,
     // we've gotten rid of the 'freqDeps' among other things.
     // Instead, we can validate that the transitive line still holds.
     // Expected: NSubstitute -> Castle.Core -> NETStandard.Library -> System.Net.Http
-    const pkg = { name: 'System.Net.Http', version: '4.3.0' };
-    const generated = depGraph.pkgPathsToRoot(pkg);
-    const baseline = depTreeConverted.pkgPathsToRoot(pkg);
-    expect(generated).toEqual(baseline);
+    expect(baselinePathsToRoot).toEqual(withRuntimeDepsPathsToRoot);
   });
 });

--- a/test/parsers/parse-core-v2.spec.ts
+++ b/test/parsers/parse-core-v2.spec.ts
@@ -8,14 +8,14 @@ import { ManifestType } from '../../lib/nuget-parser/types';
 
 describe('when generating depGraphs and runtime assemblies using the v2 parser', () => {
   it.each([
-    {
-      description: 'parse dotnet 6.0',
-      projectPath: './test/fixtures/dotnetcore/dotnet_6',
-    },
-    {
-      description: 'parse netstandard 2.1',
-      projectPath: './test/fixtures/dotnetcore/netstandard21',
-    },
+    // {
+    //   description: 'parse dotnet 6.0',
+    //   projectPath: './test/fixtures/dotnetcore/dotnet_6',
+    // },
+    // {
+    //   description: 'parse netstandard 2.1',
+    //   projectPath: './test/fixtures/dotnetcore/netstandard21',
+    // },
     {
       description: 'parse dotnet 6.0 and 7.0 but specify a targetFramework',
       projectPath: './test/fixtures/dotnetcore/dotnet_6_and_7',
@@ -56,8 +56,7 @@ describe('when generating depGraphs and runtime assemblies using the v2 parser',
       projectPath,
       'obj/project.assets.json',
       ManifestType.DOTNET_CORE,
-      false,
-      useRuntimeDependencies,
+      false
     );
 
     // Then do the same with the new functionality and validate the graph looks the same, only newer versions for runtime dependencies.
@@ -66,8 +65,7 @@ describe('when generating depGraphs and runtime assemblies using the v2 parser',
       projectPath,
       'obj/project.assets.json',
       ManifestType.DOTNET_CORE,
-      false,
-      useRuntimeDependencies,
+      false
     );
 
     // Assert that the existing logic shows an older version of a runtime dependency:

--- a/test/parsers/parse-core-v2.spec.ts
+++ b/test/parsers/parse-core-v2.spec.ts
@@ -2,20 +2,18 @@ import { describe, expect, it } from '@jest/globals';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as plugin from '../../lib';
-import * as nugetParser from '../../lib/nuget-parser';
 import * as dotnet from '../../lib/nuget-parser/cli/dotnet';
-import { ManifestType } from '../../lib/nuget-parser/types';
 
 describe('when generating depGraphs and runtime assemblies using the v2 parser', () => {
   it.each([
-    // {
-    //   description: 'parse dotnet 6.0',
-    //   projectPath: './test/fixtures/dotnetcore/dotnet_6',
-    // },
-    // {
-    //   description: 'parse netstandard 2.1',
-    //   projectPath: './test/fixtures/dotnetcore/netstandard21',
-    // },
+    {
+      description: 'parse dotnet 6.0',
+      projectPath: './test/fixtures/dotnetcore/dotnet_6',
+    },
+    {
+      description: 'parse netstandard 2.1',
+      projectPath: './test/fixtures/dotnetcore/netstandard21',
+    },
     {
       description: 'parse dotnet 6.0 and 7.0 but specify a targetFramework',
       projectPath: './test/fixtures/dotnetcore/dotnet_6_and_7',
@@ -43,63 +41,6 @@ describe('when generating depGraphs and runtime assemblies using the v2 parser',
       expect(result.dependencyGraph?.toJSON()).toEqual(expectedGraph.depGraph);
     },
   );
-
-  it('correctly generates a depGraph with or without runtime versions ', async () => {
-    const projectPath = './test/fixtures/dotnetcore/dotnet_6';
-
-    // Run a dotnet restore beforehand, in order to be able to supply a project.assets.json file
-    await dotnet.restore(projectPath);
-
-    // First generate the graph normally without new functionality.
-    let useRuntimeDependencies = false;
-    const baseline = await nugetParser.buildDepGraphFromFiles(
-      projectPath,
-      'obj/project.assets.json',
-      ManifestType.DOTNET_CORE,
-      false
-    );
-
-    // Then do the same with the new functionality and validate the graph looks the same, only newer versions for runtime dependencies.
-    useRuntimeDependencies = true;
-    const withRuntimeDeps = await nugetParser.buildDepGraphFromFiles(
-      projectPath,
-      'obj/project.assets.json',
-      ManifestType.DOTNET_CORE,
-      false
-    );
-
-    // Assert that the existing logic shows an older version of a runtime dependency:
-    expect(baseline.dependencyGraph).toBeDefined();
-    expect(baseline.dependencyGraph.getPkgs()).toContainEqual({
-      name: 'System.Net.Http',
-      version: '4.3.0',
-    });
-
-    // Assert that with runtime deps it correctly reflects the net6.0 runtime version:
-    expect(withRuntimeDeps.dependencyGraph).toBeDefined();
-    expect(withRuntimeDeps.dependencyGraph.getPkgs()).toContainEqual({
-      name: 'System.Net.Http',
-      version: '6.0.0',
-    });
-
-    // Assert that no construction of the depGraph otherwise was destroyed in the process,
-    // by looking at a non-runtime dependencies relations to the graph:
-    const pkg = { name: 'Microsoft.NETCore.Targets', version: '1.1.0' };
-
-    // Map the list to ignore versions for easier comparison, as it will otherwise fail with versions being different
-    // between baseline and runtime:
-    const baselinePathsToRoot = baseline.dependencyGraph
-      .pkgPathsToRoot(pkg)
-      .map((inner) => inner.map(({ name }) => ({ name })));
-
-    const withRuntimeDepsPathsToRoot = withRuntimeDeps.dependencyGraph
-      .pkgPathsToRoot(pkg)
-      .map((inner) => inner.map(({ name }) => ({ name })));
-
-    expect(withRuntimeDepsPathsToRoot.length).toEqual(
-      baselinePathsToRoot.length,
-    );
-  });
 
   it.each([
     {


### PR DESCRIPTION
After https://github.com/snyk/snyk-nuget-plugin/pull/172 we want to remove the optional `useRuntimeDependencies` which was never used anywhere. We were already branching out if the option `--dotnet-runtime-resolution` was specified or not, so it did not make much sense. We already have a guard in that.

We've tested this for a while and it looks stable. It was inserted as a failsafe being over-cautious, but I feel comfortable removing it again now.

This should pave the road to enable the actual implementation of what we want, the multi-result solution for multiple `<TargetFramework>`s.