### PR TITLE
feat: [OSM-695] renaming `--target-framework` to `--dotnet-target-framework`

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -71,7 +71,10 @@ export async function inspect(
       .then(createPackageTree);
   }
 
-  if (options['target-framework'] && !options['dotnet-runtime-resolution']) {
+  if (
+    options['dotnet-target-framework'] &&
+    !options['dotnet-runtime-resolution']
+  ) {
     return Promise.reject(
       new CliCommandError(
         'target framework flag is currently only supported when also scanning with runtime resolution using the `--dotnet-runtime-resolution` flag',
@@ -100,7 +103,7 @@ with the debug (-d) flag at \x1b[4mhttps://support.snyk.io/hc/en-us/requests/new
       manifestType,
       options['assets-project-name'],
       options['project-name-prefix'],
-      options['target-framework'],
+      options['dotnet-target-framework'],
     );
     return {
       dependencyGraph: result.dependencyGraph,

--- a/lib/nuget-parser/index.ts
+++ b/lib/nuget-parser/index.ts
@@ -134,7 +134,7 @@ Will attempt to build dependency graph anyway, but the operation might fail.`);
   let decidedTargetFramework: string;
   if (!targetFramework) {
     console.log(`No targetFramework supplied, defaulting to using the first in the list of the manifest (\x1b[1m${targetFrameworks[0]}\x1b[0m).
-Supply a targetFramework by using the \x1b[1m--target-framework\x1b[0m argument.`);
+Supply a targetFramework by using the \x1b[1m--dotnet-target-framework\x1b[0m argument.`);
     decidedTargetFramework = targetFrameworks[0];
   } else {
     decidedTargetFramework = targetFramework;

--- a/test/parsers/parse-core-v2.spec.ts
+++ b/test/parsers/parse-core-v2.spec.ts
@@ -32,7 +32,7 @@ describe('when generating depGraphs and runtime assemblies using the v2 parser',
 
       const result = await plugin.inspect(projectPath, manifestFile, {
         'dotnet-runtime-resolution': true,
-        'target-framework': targetFramework,
+        'dotnet-target-framework': targetFramework,
       });
 
       if (pluginApi.isMultiResult(result)) {


### PR DESCRIPTION
After doing a sync up with product we decided this is more consistent with the beta flag `--dotnet-runtime-resolution`.