### PR TITLE
fix: [OSM-699] Replace `isSupported` runtime assembly logic with shared logic from `dotnet-deps-parser`

### DIFF
--- a/lib/nuget-parser/index.ts
+++ b/lib/nuget-parser/index.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as csProjParser from './parsers/csproj-parser';
 import * as debugModule from 'debug';
+import * as depsParser from 'dotnet-deps-parser';
 import * as dotnetCoreParser from './parsers/dotnet-core-parser';
 import * as dotnetCoreV2Parser from './parsers/dotnet-core-v2-parser';
 import * as dotnetFrameworkParser from './parsers/dotnet-framework-parser';
@@ -140,7 +141,7 @@ Supply a targetFramework by using the \x1b[1m--dotnet-target-framework\x1b[0m ar
     decidedTargetFramework = targetFramework;
   }
 
-  if (!runtimeAssembly.isSupported(decidedTargetFramework)) {
+  if (!depsParser.isSupportedByV2GraphGeneration(decidedTargetFramework)) {
     throw new FileNotProcessableError(
       `runtime resolution flag is currently only supported for: .NET versions 5 and higher, all versions of .NET Core and all versions of .NET Standard projects. Supplied versions was parsed as: ${decidedTargetFramework}.`,
     );

--- a/lib/nuget-parser/runtime-assembly.ts
+++ b/lib/nuget-parser/runtime-assembly.ts
@@ -16,31 +16,6 @@ interface Versions {
   fileVersion: string;
 }
 
-// At least to keep project development iterative, don't support needle and haystack'ing dependency JSON
-// for target frameworks other than .NET 5+ and .NET Core, as other frameworks generates vastly other types of
-// .json graphs, requiring a whole other parsing strategy to extract tne runtime dependencies.
-// For a list of version naming currently available, see
-// https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks
-export function isSupported(targetFramework: string): boolean {
-  // Everything that does not start with 'net' is already game over. E.g. Windows Phone (wp) or silverlight (sl) etc.
-  if (!targetFramework.startsWith('net')) {
-    return false;
-  }
-
-  // What's left is:
-  // - .NET Core: netcoreappN.N,
-  // - .NET 5+ netN.N,
-  // - .NET Standard: netstandardN.N and
-  // - .NET Framework: netNNN, all of which we support except the latter.
-  // So if there's a dot, we're good.
-  if (targetFramework.includes('.')) {
-    return true;
-  }
-
-  // Otherwise it's something before .NET 5 and we're out
-  return false;
-}
-
 // The Nuget dependency resolution rule of lowest applicable version
 // (see https://learn.microsoft.com/en-us/nuget/concepts/dependency-resolution#lowest-applicable-version)
 // does not apply to runtime dependencies. If you resolve a dependency graph of some package, that depends on

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@snyk/cli-interface": "^2.13.0",
     "@snyk/dep-graph": "^2.7.1",
     "debug": "^4.3.4",
-    "dotnet-deps-parser": "5.3.0",
+    "dotnet-deps-parser": "5.5.1",
     "jszip": "3.10.1",
     "lodash": "^4.17.21",
     "node-cache": "^5.1.2",

--- a/test/runtime-assembly.spec.ts
+++ b/test/runtime-assembly.spec.ts
@@ -23,52 +23,6 @@ class TestFixture {
 describe('when parsing runtime assembly', () => {
   it.each([
     {
-      targetFramework: '',
-      expected: false,
-    },
-    {
-      targetFramework: 'foobar',
-      expected: false,
-    },
-    // Windows Store
-    {
-      targetFramework: 'netcore45',
-      expected: false,
-    },
-    // .NET Standard
-    {
-      targetFramework: 'netstandard1.5',
-      expected: true,
-    },
-    // .NET Core
-    {
-      targetFramework: 'netcoreapp3.1',
-      expected: true,
-    },
-    // .NET >= 5
-    {
-      targetFramework: 'net7.0',
-      expected: true,
-    },
-    // .NET Framework < 5
-    {
-      targetFramework: 'net403',
-      expected: false,
-    },
-    // .NET Framework < 5
-    {
-      targetFramework: 'net48',
-      expected: false,
-    },
-  ])(
-    'accepts or rejects specific target frameworks for runtime assembly parsing when targetFramework is: $targetFramework.original',
-    ({ targetFramework, expected }) => {
-      expect(runtimeAssembly.isSupported(targetFramework)).toEqual(expected);
-    },
-  );
-
-  it.each([
-    {
       description: 'a dotnet 6.0 project',
       project: {
         name: 'dotnet6.csproj',


### PR DESCRIPTION
See [this](https://github.com/snyk/dotnet-deps-parser/pull/84).

(Everything will fail until that is merged ☝🏻 )