### PR TITLE
feat: [OSM-347] Return multiple results when no specific `TargetFramework` has been specified

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -118,7 +118,7 @@ with the debug (-d) flag at \x1b[4mhttps://support.snyk.io/hc/en-us/requests/new
 
     for (const result of results) {
       multiProjectResult.scannedProjects.push({
-        targetFile: targetFile,
+        targetFile: `${targetFile} [${result.targetFramework}]`, // Improve UX for the CLI to define what targetFramework was scanned.
         depGraph: result.dependencyGraph,
         meta: {
           targetRuntime: result.targetFramework,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -118,7 +118,7 @@ with the debug (-d) flag at \x1b[4mhttps://support.snyk.io/hc/en-us/requests/new
 
     for (const result of results) {
       multiProjectResult.scannedProjects.push({
-        targetFile: `${targetFile} [${result.targetFramework}]`, // Improve UX for the CLI to define what targetFramework was scanned.
+        targetFile: targetFile,
         depGraph: result.dependencyGraph,
         meta: {
           targetRuntime: result.targetFramework,

--- a/lib/nuget-parser/index.ts
+++ b/lib/nuget-parser/index.ts
@@ -246,7 +246,8 @@ export async function buildDepTreeFromFiles(
     return Promise.reject(error);
   }
 
-  // TODO: OSM-347 - use more than just the first one we find
+  // Only supports the first targetFramework we find.
+  // Use the newer `buildDepGraphFromFiles` for better support for multiple target frameworks.
   const targetFramework =
     targetFrameworks.length > 0 ? targetFrameworks[0].original : undefined;
   tree.meta = {

--- a/lib/nuget-parser/index.ts
+++ b/lib/nuget-parser/index.ts
@@ -133,12 +133,18 @@ Will attempt to build dependency graph anyway, but the operation might fail.`);
     : targetFrameworks.filter((framework) => {
         if (!depsParser.isSupportedByV2GraphGeneration(framework)) {
           console.log(
-            `\x1b[33m⚠ WARNING\x1b[0m: runtime resolution flag is currently only supported for: .NET versions 5 and higher, all versions of .NET Core and all versions of .NET Standard projects. Supplied version was parsed as: ${framework}, which will be skipped.`,
+            `\x1b[33m⚠ WARNING\x1b[0m: The runtime resolution flag is currently only supported for the following TargetFrameworks: .NET versions 5 and higher, all versions of .NET Core and all versions of .NET Standard. Detected a TargetFramework: \x1b[1m${framework}\x1b[0m, which will be skipped.`,
           );
           return false;
         }
         return true;
       });
+
+  if (decidedTargetFrameworks.length == 0) {
+    throw new InvalidManifestError(
+      `Was not able to find any supported TargetFrameworks to scan, aborting`,
+    );
+  }
 
   const results: DotnetCoreV2Results = [];
   for (const decidedTargetFramework of decidedTargetFrameworks) {

--- a/lib/nuget-parser/types.ts
+++ b/lib/nuget-parser/types.ts
@@ -89,4 +89,4 @@ export interface DotnetCoreV2Result {
   targetFramework: string | undefined;
 }
 
-export type DotnetCoreV2Results = DotnetCoreV2Result[]
+export type DotnetCoreV2Results = DotnetCoreV2Result[];

--- a/lib/nuget-parser/types.ts
+++ b/lib/nuget-parser/types.ts
@@ -1,3 +1,5 @@
+import * as depGraphLib from '@snyk/dep-graph';
+
 export interface TargetFramework {
   framework: string;
   original: string;
@@ -80,3 +82,11 @@ export interface DotNetFile {
   name: string;
   contents: string;
 }
+
+// V2 dependency graph result
+export interface DotnetCoreV2Result {
+  dependencyGraph: depGraphLib.DepGraph;
+  targetFramework: string | undefined;
+}
+
+export type DotnetCoreV2Results = DotnetCoreV2Result[]

--- a/test/dep-graph.spec.ts
+++ b/test/dep-graph.spec.ts
@@ -63,12 +63,16 @@ class TestFixture {
 
     // Then do the same with the new functionality and validate the graph looks the same,
     // only with newer versions for the runtime-specific dependencies. The rest should be identical.
-    const withRuntimeDeps = await nugetParser.buildDepGraphFromFiles(
+    const withRuntimeDepsResults = await nugetParser.buildDepGraphFromFiles(
       tempDir,
       'obj/project.assets.json',
       ManifestType.DOTNET_CORE,
       false,
     );
+
+    expect(withRuntimeDepsResults.length).toEqual(1);
+
+    const withRuntimeDeps = withRuntimeDepsResults[0];
     expect(withRuntimeDeps.dependencyGraph).toBeDefined();
 
     // Assert that the existing logic shows an older version of a runtime dependency:
@@ -133,12 +137,13 @@ class TestFixture {
     const tempDir = projectDirs['noDeps'];
     await dotnet.restore(tempDir);
 
-    const result = await nugetParser.buildDepGraphFromFiles(
+    const results = await nugetParser.buildDepGraphFromFiles(
       tempDir,
       'obj/project.assets.json',
       ManifestType.DOTNET_CORE,
       false,
     );
-    expect(result.dependencyGraph).toBeDefined();
+    expect(results.length).toEqual(1);
+    expect(results[0].dependencyGraph).toBeDefined();
   });
 });

--- a/test/fixtures/dotnetcore/dotnet_6_and_7/expected_depgraphs.json
+++ b/test/fixtures/dotnetcore/dotnet_6_and_7/expected_depgraphs.json
@@ -1,0 +1,5710 @@
+[
+  {
+    "schemaVersion": "1.3.0",
+    "pkgManager": {
+      "name": "nuget"
+    },
+    "pkgs": [
+      {
+        "id": "dotnet_6_and_7@1.0.0",
+        "info": {
+          "name": "dotnet_6_and_7",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "NSubstitute@4.3.0",
+        "info": {
+          "name": "NSubstitute",
+          "version": "4.3.0"
+        }
+      },
+      {
+        "id": "Castle.Core@4.0.0",
+        "info": {
+          "name": "Castle.Core",
+          "version": "4.0.0"
+        }
+      },
+      {
+        "id": "NETStandard.Library@1.6.1",
+        "info": {
+          "name": "NETStandard.Library",
+          "version": "1.6.1"
+        }
+      },
+      {
+        "id": "Microsoft.NETCore.Platforms@1.1.0",
+        "info": {
+          "name": "Microsoft.NETCore.Platforms",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "id": "Microsoft.Win32.Primitives@6.0.0",
+        "info": {
+          "name": "Microsoft.Win32.Primitives",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.NETCore.Targets@1.1.0",
+        "info": {
+          "name": "Microsoft.NETCore.Targets",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "id": "System.Runtime@6.0.0",
+        "info": {
+          "name": "System.Runtime",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.AppContext@6.0.0",
+        "info": {
+          "name": "System.AppContext",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Collections@6.0.0",
+        "info": {
+          "name": "System.Collections",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Collections.Concurrent@6.0.0",
+        "info": {
+          "name": "System.Collections.Concurrent",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Diagnostics.Debug@6.0.0",
+        "info": {
+          "name": "System.Diagnostics.Debug",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Diagnostics.Tracing@6.0.0",
+        "info": {
+          "name": "System.Diagnostics.Tracing",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Globalization@6.0.0",
+        "info": {
+          "name": "System.Globalization",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection@6.0.0",
+        "info": {
+          "name": "System.Reflection",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.IO@6.0.0",
+        "info": {
+          "name": "System.IO",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Text.Encoding@6.0.0",
+        "info": {
+          "name": "System.Text.Encoding",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Threading.Tasks@6.0.0",
+        "info": {
+          "name": "System.Threading.Tasks",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection.Primitives@6.0.0",
+        "info": {
+          "name": "System.Reflection.Primitives",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Resources.ResourceManager@6.0.0",
+        "info": {
+          "name": "System.Resources.ResourceManager",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Runtime.Extensions@6.0.0",
+        "info": {
+          "name": "System.Runtime.Extensions",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Threading@6.0.0",
+        "info": {
+          "name": "System.Threading",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Console@6.0.0",
+        "info": {
+          "name": "System.Console",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Diagnostics.Tools@6.0.0",
+        "info": {
+          "name": "System.Diagnostics.Tools",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Globalization.Calendars@6.0.0",
+        "info": {
+          "name": "System.Globalization.Calendars",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.IO.Compression@6.0.0",
+        "info": {
+          "name": "System.IO.Compression",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Buffers@6.0.0",
+        "info": {
+          "name": "System.Buffers",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Runtime.Handles@6.0.0",
+        "info": {
+          "name": "System.Runtime.Handles",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Runtime.InteropServices@6.0.0",
+        "info": {
+          "name": "System.Runtime.InteropServices",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "runtime.native.System@4.3.0",
+        "info": {
+          "name": "runtime.native.System",
+          "version": "4.3.0"
+        }
+      },
+      {
+        "id": "runtime.native.System.IO.Compression@4.3.0",
+        "info": {
+          "name": "runtime.native.System.IO.Compression",
+          "version": "4.3.0"
+        }
+      },
+      {
+        "id": "System.IO.Compression.ZipFile@6.0.0",
+        "info": {
+          "name": "System.IO.Compression.ZipFile",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.IO.FileSystem@6.0.0",
+        "info": {
+          "name": "System.IO.FileSystem",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.IO.FileSystem.Primitives@6.0.0",
+        "info": {
+          "name": "System.IO.FileSystem.Primitives",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Linq@6.0.0",
+        "info": {
+          "name": "System.Linq",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Linq.Expressions@6.0.0",
+        "info": {
+          "name": "System.Linq.Expressions",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.ObjectModel@6.0.0",
+        "info": {
+          "name": "System.ObjectModel",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection.Emit@6.0.0",
+        "info": {
+          "name": "System.Reflection.Emit",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection.Emit.ILGeneration@6.0.0",
+        "info": {
+          "name": "System.Reflection.Emit.ILGeneration",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection.Emit.Lightweight@6.0.0",
+        "info": {
+          "name": "System.Reflection.Emit.Lightweight",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection.Extensions@6.0.0",
+        "info": {
+          "name": "System.Reflection.Extensions",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection.TypeExtensions@6.0.0",
+        "info": {
+          "name": "System.Reflection.TypeExtensions",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Net.Http@6.0.0",
+        "info": {
+          "name": "System.Net.Http",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Diagnostics.DiagnosticSource@6.0.0",
+        "info": {
+          "name": "System.Diagnostics.DiagnosticSource",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Globalization.Extensions@6.0.0",
+        "info": {
+          "name": "System.Globalization.Extensions",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Net.Primitives@6.0.0",
+        "info": {
+          "name": "System.Net.Primitives",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.Algorithms@6.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.Algorithms",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Runtime.Numerics@6.0.0",
+        "info": {
+          "name": "System.Runtime.Numerics",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.Encoding@6.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.Encoding",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.Primitives@6.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.Primitives",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+        "info": {
+          "name": "runtime.native.System.Security.Cryptography.OpenSsl",
+          "version": "4.3.0"
+        }
+      },
+      {
+        "id": "runtime.native.System.Security.Cryptography.Apple@4.3.0",
+        "info": {
+          "name": "runtime.native.System.Security.Cryptography.Apple",
+          "version": "4.3.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.OpenSsl@6.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.OpenSsl",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.X509Certificates@6.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.X509Certificates",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.Cng@6.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.Cng",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.Csp@6.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.Csp",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "runtime.native.System.Net.Http@4.3.0",
+        "info": {
+          "name": "runtime.native.System.Net.Http",
+          "version": "4.3.0"
+        }
+      },
+      {
+        "id": "System.Net.Sockets@6.0.0",
+        "info": {
+          "name": "System.Net.Sockets",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Runtime.InteropServices.RuntimeInformation@6.0.0",
+        "info": {
+          "name": "System.Runtime.InteropServices.RuntimeInformation",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Text.Encoding.Extensions@6.0.0",
+        "info": {
+          "name": "System.Text.Encoding.Extensions",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Text.RegularExpressions@6.0.0",
+        "info": {
+          "name": "System.Text.RegularExpressions",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Threading.Timer@6.0.0",
+        "info": {
+          "name": "System.Threading.Timer",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Xml.ReaderWriter@6.0.0",
+        "info": {
+          "name": "System.Xml.ReaderWriter",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Threading.Tasks.Extensions@6.0.0",
+        "info": {
+          "name": "System.Threading.Tasks.Extensions",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Xml.XDocument@6.0.0",
+        "info": {
+          "name": "System.Xml.XDocument",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Collections.Specialized@6.0.0",
+        "info": {
+          "name": "System.Collections.Specialized",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Collections.NonGeneric@6.0.0",
+        "info": {
+          "name": "System.Collections.NonGeneric",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.ComponentModel@6.0.0",
+        "info": {
+          "name": "System.ComponentModel",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.ComponentModel.TypeConverter@6.0.0",
+        "info": {
+          "name": "System.ComponentModel.TypeConverter",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.ComponentModel.Primitives@6.0.0",
+        "info": {
+          "name": "System.ComponentModel.Primitives",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Diagnostics.TraceSource@6.0.0",
+        "info": {
+          "name": "System.Diagnostics.TraceSource",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Dynamic.Runtime@6.0.0",
+        "info": {
+          "name": "System.Dynamic.Runtime",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Xml.XmlDocument@6.0.0",
+        "info": {
+          "name": "System.Xml.XmlDocument",
+          "version": "6.0.0"
+        }
+      }
+    ],
+    "graph": {
+      "rootNodeId": "root-node",
+      "nodes": [
+        {
+          "nodeId": "root-node",
+          "pkgId": "dotnet_6_and_7@1.0.0",
+          "deps": [
+            {
+              "nodeId": "NSubstitute@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "NSubstitute@4.3.0",
+          "pkgId": "NSubstitute@4.3.0",
+          "deps": [
+            {
+              "nodeId": "Castle.Core@4.4.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "Castle.Core@4.4.1",
+          "pkgId": "Castle.Core@4.0.0",
+          "deps": [
+            {
+              "nodeId": "NETStandard.Library@1.6.1"
+            },
+            {
+              "nodeId": "System.Collections.Specialized@4.3.0"
+            },
+            {
+              "nodeId": "System.ComponentModel@4.3.0"
+            },
+            {
+              "nodeId": "System.ComponentModel.TypeConverter@4.3.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.TraceSource@4.3.0"
+            },
+            {
+              "nodeId": "System.Dynamic.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Emit@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.TypeExtensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Xml.XmlDocument@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "NETStandard.Library@1.6.1",
+          "pkgId": "NETStandard.Library@1.6.1",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0"
+            },
+            {
+              "nodeId": "Microsoft.Win32.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.AppContext@4.3.0"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0"
+            },
+            {
+              "nodeId": "System.Collections.Concurrent@4.3.0"
+            },
+            {
+              "nodeId": "System.Console@4.3.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Tools@4.3.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.Tracing@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization.Calendars@4.3.0"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.Compression@4.3.0"
+            },
+            {
+              "nodeId": "System.IO.Compression.ZipFile@4.3.0"
+            },
+            {
+              "nodeId": "System.IO.FileSystem@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.FileSystem.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Linq@4.3.0"
+            },
+            {
+              "nodeId": "System.Linq.Expressions@4.3.0"
+            },
+            {
+              "nodeId": "System.Net.Http@4.3.0"
+            },
+            {
+              "nodeId": "System.Net.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Net.Sockets@4.3.0"
+            },
+            {
+              "nodeId": "System.ObjectModel@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices.RuntimeInformation@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Numerics@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Algorithms@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.X509Certificates@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.RegularExpressions@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Timer@4.3.0"
+            },
+            {
+              "nodeId": "System.Xml.ReaderWriter@4.3.0"
+            },
+            {
+              "nodeId": "System.Xml.XDocument@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.NETCore.Platforms@1.1.0",
+          "pkgId": "Microsoft.NETCore.Platforms@1.1.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Win32.Primitives@4.3.0",
+          "pkgId": "Microsoft.Win32.Primitives@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned",
+          "pkgId": "Microsoft.NETCore.Platforms@1.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.NETCore.Targets@1.1.0",
+          "pkgId": "Microsoft.NETCore.Targets@1.1.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Runtime@4.3.0",
+          "pkgId": "System.Runtime@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned",
+          "pkgId": "Microsoft.NETCore.Targets@1.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.AppContext@4.3.0",
+          "pkgId": "System.AppContext@6.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Runtime@4.3.0:pruned",
+          "pkgId": "System.Runtime@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Collections@4.3.0",
+          "pkgId": "System.Collections@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Collections.Concurrent@4.3.0",
+          "pkgId": "System.Collections.Concurrent@6.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.Tracing@4.3.0"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Collections@4.3.0:pruned",
+          "pkgId": "System.Collections@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Diagnostics.Debug@4.3.0",
+          "pkgId": "System.Diagnostics.Debug@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Diagnostics.Tracing@4.3.0",
+          "pkgId": "System.Diagnostics.Tracing@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Globalization@4.3.0",
+          "pkgId": "System.Globalization@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection@4.3.0",
+          "pkgId": "System.Reflection@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.IO@4.3.0",
+          "pkgId": "System.IO@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Text.Encoding@4.3.0",
+          "pkgId": "System.Text.Encoding@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Threading.Tasks@4.3.0",
+          "pkgId": "System.Threading.Tasks@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.Primitives@4.3.0",
+          "pkgId": "System.Reflection.Primitives@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Resources.ResourceManager@4.3.0",
+          "pkgId": "System.Resources.ResourceManager@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Globalization@4.3.0:pruned",
+          "pkgId": "System.Globalization@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Reflection@4.3.0:pruned",
+          "pkgId": "System.Reflection@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Runtime.Extensions@4.3.0",
+          "pkgId": "System.Runtime.Extensions@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Threading@4.3.0",
+          "pkgId": "System.Threading@6.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Threading.Tasks@4.3.0:pruned",
+          "pkgId": "System.Threading.Tasks@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Console@4.3.0",
+          "pkgId": "System.Console@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.IO@4.3.0:pruned",
+          "pkgId": "System.IO@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Text.Encoding@4.3.0:pruned",
+          "pkgId": "System.Text.Encoding@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Diagnostics.Debug@4.3.0:pruned",
+          "pkgId": "System.Diagnostics.Debug@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Diagnostics.Tools@4.3.0",
+          "pkgId": "System.Diagnostics.Tools@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Diagnostics.Tracing@4.3.0:pruned",
+          "pkgId": "System.Diagnostics.Tracing@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Globalization.Calendars@4.3.0",
+          "pkgId": "System.Globalization.Calendars@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.IO.Compression@4.3.0",
+          "pkgId": "System.IO.Compression@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Buffers@4.3.0"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0:pruned"
+            },
+            {
+              "nodeId": "runtime.native.System@4.3.0"
+            },
+            {
+              "nodeId": "runtime.native.System.IO.Compression@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Buffers@4.3.0",
+          "pkgId": "System.Buffers@6.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Tracing@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Resources.ResourceManager@4.3.0:pruned",
+          "pkgId": "System.Resources.ResourceManager@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Threading@4.3.0:pruned",
+          "pkgId": "System.Threading@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Runtime.Extensions@4.3.0:pruned",
+          "pkgId": "System.Runtime.Extensions@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Runtime.Handles@4.3.0",
+          "pkgId": "System.Runtime.Handles@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Runtime.InteropServices@4.3.0",
+          "pkgId": "System.Runtime.InteropServices@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.Primitives@4.3.0:pruned",
+          "pkgId": "System.Reflection.Primitives@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Runtime.Handles@4.3.0:pruned",
+          "pkgId": "System.Runtime.Handles@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "runtime.native.System@4.3.0",
+          "pkgId": "runtime.native.System@4.3.0",
+          "deps": []
+        },
+        {
+          "nodeId": "runtime.native.System.IO.Compression@4.3.0",
+          "pkgId": "runtime.native.System.IO.Compression@4.3.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.IO.Compression.ZipFile@4.3.0",
+          "pkgId": "System.IO.Compression.ZipFile@6.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Buffers@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.Compression@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.FileSystem@4.3.0"
+            },
+            {
+              "nodeId": "System.IO.FileSystem.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Buffers@4.3.0:pruned",
+          "pkgId": "System.Buffers@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.IO.Compression@4.3.0:pruned",
+          "pkgId": "System.IO.Compression@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.IO.FileSystem@4.3.0",
+          "pkgId": "System.IO.FileSystem@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.FileSystem.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.IO.FileSystem.Primitives@4.3.0",
+          "pkgId": "System.IO.FileSystem.Primitives@6.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.IO.FileSystem.Primitives@4.3.0:pruned",
+          "pkgId": "System.IO.FileSystem.Primitives@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.IO.FileSystem@4.3.0:pruned",
+          "pkgId": "System.IO.FileSystem@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Linq@4.3.0",
+          "pkgId": "System.Linq@6.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Linq.Expressions@4.3.0",
+          "pkgId": "System.Linq.Expressions@6.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Linq@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.ObjectModel@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Emit@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.Emit.ILGeneration@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Emit.Lightweight@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.TypeExtensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Linq@4.3.0:pruned",
+          "pkgId": "System.Linq@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.ObjectModel@4.3.0",
+          "pkgId": "System.ObjectModel@6.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.Emit@4.3.0",
+          "pkgId": "System.Reflection.Emit@6.0.0",
+          "deps": [
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Emit.ILGeneration@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.Emit.ILGeneration@4.3.0",
+          "pkgId": "System.Reflection.Emit.ILGeneration@6.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.Emit.ILGeneration@4.3.0:pruned",
+          "pkgId": "System.Reflection.Emit.ILGeneration@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Reflection.Emit.Lightweight@4.3.0",
+          "pkgId": "System.Reflection.Emit.Lightweight@6.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Emit.ILGeneration@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.Extensions@4.3.0",
+          "pkgId": "System.Reflection.Extensions@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.TypeExtensions@4.3.0",
+          "pkgId": "System.Reflection.TypeExtensions@6.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Net.Http@4.3.0",
+          "pkgId": "System.Net.Http@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.DiagnosticSource@4.3.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.Tracing@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.FileSystem@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Net.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Algorithms@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.OpenSsl@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.X509Certificates@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0:pruned"
+            },
+            {
+              "nodeId": "runtime.native.System@4.3.0:pruned"
+            },
+            {
+              "nodeId": "runtime.native.System.Net.Http@4.3.0:pruned"
+            },
+            {
+              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Diagnostics.DiagnosticSource@4.3.0",
+          "pkgId": "System.Diagnostics.DiagnosticSource@6.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Tracing@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Globalization.Extensions@4.3.0",
+          "pkgId": "System.Globalization.Extensions@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Runtime.InteropServices@4.3.0:pruned",
+          "pkgId": "System.Runtime.InteropServices@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Net.Primitives@4.3.0",
+          "pkgId": "System.Net.Primitives@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Algorithms@4.3.0",
+          "pkgId": "System.Security.Cryptography.Algorithms@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Numerics@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "runtime.native.System.Security.Cryptography.Apple@4.3.0"
+            },
+            {
+              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Runtime.Numerics@4.3.0",
+          "pkgId": "System.Runtime.Numerics@6.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Encoding@4.3.0",
+          "pkgId": "System.Security.Cryptography.Encoding@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Collections.Concurrent@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Linq@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Collections.Concurrent@4.3.0:pruned",
+          "pkgId": "System.Collections.Concurrent@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Primitives@4.3.0",
+          "pkgId": "System.Security.Cryptography.Primitives@6.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+          "pkgId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned",
+          "pkgId": "System.Security.Cryptography.Primitives@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "runtime.native.System.Security.Cryptography.Apple@4.3.0",
+          "pkgId": "runtime.native.System.Security.Cryptography.Apple@4.3.0",
+          "deps": []
+        },
+        {
+          "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned",
+          "pkgId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Encoding@4.3.0:pruned",
+          "pkgId": "System.Security.Cryptography.Encoding@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Security.Cryptography.OpenSsl@4.3.0",
+          "pkgId": "System.Security.Cryptography.OpenSsl@6.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Numerics@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Algorithms@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Runtime.Numerics@4.3.0:pruned",
+          "pkgId": "System.Runtime.Numerics@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Algorithms@4.3.0:pruned",
+          "pkgId": "System.Security.Cryptography.Algorithms@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Security.Cryptography.X509Certificates@4.3.0",
+          "pkgId": "System.Security.Cryptography.X509Certificates@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization.Calendars@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.FileSystem@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.FileSystem.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Numerics@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Algorithms@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Cng@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Csp@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.OpenSsl@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            },
+            {
+              "nodeId": "runtime.native.System@4.3.0:pruned"
+            },
+            {
+              "nodeId": "runtime.native.System.Net.Http@4.3.0"
+            },
+            {
+              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Globalization.Calendars@4.3.0:pruned",
+          "pkgId": "System.Globalization.Calendars@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Cng@4.3.0",
+          "pkgId": "System.Security.Cryptography.Cng@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Algorithms@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Csp@4.3.0",
+          "pkgId": "System.Security.Cryptography.Csp@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Algorithms@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Security.Cryptography.OpenSsl@4.3.0:pruned",
+          "pkgId": "System.Security.Cryptography.OpenSsl@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "runtime.native.System@4.3.0:pruned",
+          "pkgId": "runtime.native.System@4.3.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "runtime.native.System.Net.Http@4.3.0",
+          "pkgId": "runtime.native.System.Net.Http@4.3.0",
+          "deps": []
+        },
+        {
+          "nodeId": "runtime.native.System.Net.Http@4.3.0:pruned",
+          "pkgId": "runtime.native.System.Net.Http@4.3.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Net.Primitives@4.3.0:pruned",
+          "pkgId": "System.Net.Primitives@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Net.Sockets@4.3.0",
+          "pkgId": "System.Net.Sockets@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Net.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.ObjectModel@4.3.0:pruned",
+          "pkgId": "System.ObjectModel@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Reflection.Extensions@4.3.0:pruned",
+          "pkgId": "System.Reflection.Extensions@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Runtime.InteropServices.RuntimeInformation@4.3.0",
+          "pkgId": "System.Runtime.InteropServices.RuntimeInformation@6.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            },
+            {
+              "nodeId": "runtime.native.System@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Security.Cryptography.X509Certificates@4.3.0:pruned",
+          "pkgId": "System.Security.Cryptography.X509Certificates@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Text.Encoding.Extensions@4.3.0",
+          "pkgId": "System.Text.Encoding.Extensions@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Text.RegularExpressions@4.3.0",
+          "pkgId": "System.Text.RegularExpressions@6.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Threading.Timer@4.3.0",
+          "pkgId": "System.Threading.Timer@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Xml.ReaderWriter@4.3.0",
+          "pkgId": "System.Xml.ReaderWriter@6.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.FileSystem@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.FileSystem.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.RegularExpressions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks.Extensions@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Text.Encoding.Extensions@4.3.0:pruned",
+          "pkgId": "System.Text.Encoding.Extensions@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Text.RegularExpressions@4.3.0:pruned",
+          "pkgId": "System.Text.RegularExpressions@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Threading.Tasks.Extensions@4.3.0",
+          "pkgId": "System.Threading.Tasks.Extensions@6.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Xml.XDocument@4.3.0",
+          "pkgId": "System.Xml.XDocument@6.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Tools@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Xml.ReaderWriter@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Diagnostics.Tools@4.3.0:pruned",
+          "pkgId": "System.Diagnostics.Tools@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Xml.ReaderWriter@4.3.0:pruned",
+          "pkgId": "System.Xml.ReaderWriter@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Collections.Specialized@4.3.0",
+          "pkgId": "System.Collections.Specialized@6.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections.NonGeneric@4.3.0"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Collections.NonGeneric@4.3.0",
+          "pkgId": "System.Collections.NonGeneric@6.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Globalization.Extensions@4.3.0:pruned",
+          "pkgId": "System.Globalization.Extensions@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.ComponentModel@4.3.0",
+          "pkgId": "System.ComponentModel@6.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.ComponentModel.TypeConverter@4.3.0",
+          "pkgId": "System.ComponentModel.TypeConverter@6.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Collections.NonGeneric@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Collections.Specialized@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.ComponentModel@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.ComponentModel.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Linq@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.TypeExtensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Collections.NonGeneric@4.3.0:pruned",
+          "pkgId": "System.Collections.NonGeneric@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Collections.Specialized@4.3.0:pruned",
+          "pkgId": "System.Collections.Specialized@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.ComponentModel@4.3.0:pruned",
+          "pkgId": "System.ComponentModel@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.ComponentModel.Primitives@4.3.0",
+          "pkgId": "System.ComponentModel.Primitives@6.0.0",
+          "deps": [
+            {
+              "nodeId": "System.ComponentModel@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.TypeExtensions@4.3.0:pruned",
+          "pkgId": "System.Reflection.TypeExtensions@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Diagnostics.TraceSource@4.3.0",
+          "pkgId": "System.Diagnostics.TraceSource@6.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            },
+            {
+              "nodeId": "runtime.native.System@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Dynamic.Runtime@4.3.0",
+          "pkgId": "System.Dynamic.Runtime@6.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Linq@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Linq.Expressions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.ObjectModel@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Emit@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Emit.ILGeneration@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.TypeExtensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Linq.Expressions@4.3.0:pruned",
+          "pkgId": "System.Linq.Expressions@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Reflection.Emit@4.3.0:pruned",
+          "pkgId": "System.Reflection.Emit@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Xml.XmlDocument@4.3.0",
+          "pkgId": "System.Xml.XmlDocument@6.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Xml.ReaderWriter@4.3.0:pruned"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "schemaVersion": "1.3.0",
+    "pkgManager": {
+      "name": "nuget"
+    },
+    "pkgs": [
+      {
+        "id": "dotnet_6_and_7@1.0.0",
+        "info": {
+          "name": "dotnet_6_and_7",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "NSubstitute@4.3.0",
+        "info": {
+          "name": "NSubstitute",
+          "version": "4.3.0"
+        }
+      },
+      {
+        "id": "Castle.Core@4.0.0",
+        "info": {
+          "name": "Castle.Core",
+          "version": "4.0.0"
+        }
+      },
+      {
+        "id": "NETStandard.Library@1.6.1",
+        "info": {
+          "name": "NETStandard.Library",
+          "version": "1.6.1"
+        }
+      },
+      {
+        "id": "Microsoft.NETCore.Platforms@1.1.0",
+        "info": {
+          "name": "Microsoft.NETCore.Platforms",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "id": "Microsoft.Win32.Primitives@7.0.0",
+        "info": {
+          "name": "Microsoft.Win32.Primitives",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.NETCore.Targets@1.1.0",
+        "info": {
+          "name": "Microsoft.NETCore.Targets",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "id": "System.Runtime@7.0.0",
+        "info": {
+          "name": "System.Runtime",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.AppContext@7.0.0",
+        "info": {
+          "name": "System.AppContext",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Collections@7.0.0",
+        "info": {
+          "name": "System.Collections",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Collections.Concurrent@7.0.0",
+        "info": {
+          "name": "System.Collections.Concurrent",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Diagnostics.Debug@7.0.0",
+        "info": {
+          "name": "System.Diagnostics.Debug",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Diagnostics.Tracing@7.0.0",
+        "info": {
+          "name": "System.Diagnostics.Tracing",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Globalization@7.0.0",
+        "info": {
+          "name": "System.Globalization",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection@7.0.0",
+        "info": {
+          "name": "System.Reflection",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.IO@7.0.0",
+        "info": {
+          "name": "System.IO",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Text.Encoding@7.0.0",
+        "info": {
+          "name": "System.Text.Encoding",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Threading.Tasks@7.0.0",
+        "info": {
+          "name": "System.Threading.Tasks",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection.Primitives@7.0.0",
+        "info": {
+          "name": "System.Reflection.Primitives",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Resources.ResourceManager@7.0.0",
+        "info": {
+          "name": "System.Resources.ResourceManager",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Runtime.Extensions@7.0.0",
+        "info": {
+          "name": "System.Runtime.Extensions",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Threading@7.0.0",
+        "info": {
+          "name": "System.Threading",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Console@7.0.0",
+        "info": {
+          "name": "System.Console",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Diagnostics.Tools@7.0.0",
+        "info": {
+          "name": "System.Diagnostics.Tools",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Globalization.Calendars@7.0.0",
+        "info": {
+          "name": "System.Globalization.Calendars",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.IO.Compression@7.0.0",
+        "info": {
+          "name": "System.IO.Compression",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Buffers@7.0.0",
+        "info": {
+          "name": "System.Buffers",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Runtime.Handles@7.0.0",
+        "info": {
+          "name": "System.Runtime.Handles",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Runtime.InteropServices@7.0.0",
+        "info": {
+          "name": "System.Runtime.InteropServices",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "runtime.native.System@4.3.0",
+        "info": {
+          "name": "runtime.native.System",
+          "version": "4.3.0"
+        }
+      },
+      {
+        "id": "runtime.native.System.IO.Compression@4.3.0",
+        "info": {
+          "name": "runtime.native.System.IO.Compression",
+          "version": "4.3.0"
+        }
+      },
+      {
+        "id": "System.IO.Compression.ZipFile@7.0.0",
+        "info": {
+          "name": "System.IO.Compression.ZipFile",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.IO.FileSystem@7.0.0",
+        "info": {
+          "name": "System.IO.FileSystem",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.IO.FileSystem.Primitives@7.0.0",
+        "info": {
+          "name": "System.IO.FileSystem.Primitives",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Linq@7.0.0",
+        "info": {
+          "name": "System.Linq",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Linq.Expressions@7.0.0",
+        "info": {
+          "name": "System.Linq.Expressions",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.ObjectModel@7.0.0",
+        "info": {
+          "name": "System.ObjectModel",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection.Emit@7.0.0",
+        "info": {
+          "name": "System.Reflection.Emit",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection.Emit.ILGeneration@7.0.0",
+        "info": {
+          "name": "System.Reflection.Emit.ILGeneration",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection.Emit.Lightweight@7.0.0",
+        "info": {
+          "name": "System.Reflection.Emit.Lightweight",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection.Extensions@7.0.0",
+        "info": {
+          "name": "System.Reflection.Extensions",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection.TypeExtensions@7.0.0",
+        "info": {
+          "name": "System.Reflection.TypeExtensions",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Net.Http@7.0.0",
+        "info": {
+          "name": "System.Net.Http",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Diagnostics.DiagnosticSource@7.0.0",
+        "info": {
+          "name": "System.Diagnostics.DiagnosticSource",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Globalization.Extensions@7.0.0",
+        "info": {
+          "name": "System.Globalization.Extensions",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Net.Primitives@7.0.0",
+        "info": {
+          "name": "System.Net.Primitives",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.Algorithms@7.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.Algorithms",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Runtime.Numerics@7.0.0",
+        "info": {
+          "name": "System.Runtime.Numerics",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.Encoding@7.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.Encoding",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.Primitives@7.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.Primitives",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+        "info": {
+          "name": "runtime.native.System.Security.Cryptography.OpenSsl",
+          "version": "4.3.0"
+        }
+      },
+      {
+        "id": "runtime.native.System.Security.Cryptography.Apple@4.3.0",
+        "info": {
+          "name": "runtime.native.System.Security.Cryptography.Apple",
+          "version": "4.3.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.OpenSsl@7.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.OpenSsl",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.X509Certificates@7.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.X509Certificates",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.Cng@7.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.Cng",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.Csp@7.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.Csp",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "runtime.native.System.Net.Http@4.3.0",
+        "info": {
+          "name": "runtime.native.System.Net.Http",
+          "version": "4.3.0"
+        }
+      },
+      {
+        "id": "System.Net.Sockets@7.0.0",
+        "info": {
+          "name": "System.Net.Sockets",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Runtime.InteropServices.RuntimeInformation@7.0.0",
+        "info": {
+          "name": "System.Runtime.InteropServices.RuntimeInformation",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Text.Encoding.Extensions@7.0.0",
+        "info": {
+          "name": "System.Text.Encoding.Extensions",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Text.RegularExpressions@7.0.0",
+        "info": {
+          "name": "System.Text.RegularExpressions",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Threading.Timer@7.0.0",
+        "info": {
+          "name": "System.Threading.Timer",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Xml.ReaderWriter@7.0.0",
+        "info": {
+          "name": "System.Xml.ReaderWriter",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Threading.Tasks.Extensions@7.0.0",
+        "info": {
+          "name": "System.Threading.Tasks.Extensions",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Xml.XDocument@7.0.0",
+        "info": {
+          "name": "System.Xml.XDocument",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Collections.Specialized@7.0.0",
+        "info": {
+          "name": "System.Collections.Specialized",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Collections.NonGeneric@7.0.0",
+        "info": {
+          "name": "System.Collections.NonGeneric",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.ComponentModel@7.0.0",
+        "info": {
+          "name": "System.ComponentModel",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.ComponentModel.TypeConverter@7.0.0",
+        "info": {
+          "name": "System.ComponentModel.TypeConverter",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.ComponentModel.Primitives@7.0.0",
+        "info": {
+          "name": "System.ComponentModel.Primitives",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Diagnostics.TraceSource@7.0.0",
+        "info": {
+          "name": "System.Diagnostics.TraceSource",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Dynamic.Runtime@7.0.0",
+        "info": {
+          "name": "System.Dynamic.Runtime",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "System.Xml.XmlDocument@7.0.0",
+        "info": {
+          "name": "System.Xml.XmlDocument",
+          "version": "7.0.0"
+        }
+      }
+    ],
+    "graph": {
+      "rootNodeId": "root-node",
+      "nodes": [
+        {
+          "nodeId": "root-node",
+          "pkgId": "dotnet_6_and_7@1.0.0",
+          "deps": [
+            {
+              "nodeId": "NSubstitute@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "NSubstitute@4.3.0",
+          "pkgId": "NSubstitute@4.3.0",
+          "deps": [
+            {
+              "nodeId": "Castle.Core@4.4.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "Castle.Core@4.4.1",
+          "pkgId": "Castle.Core@4.0.0",
+          "deps": [
+            {
+              "nodeId": "NETStandard.Library@1.6.1"
+            },
+            {
+              "nodeId": "System.Collections.Specialized@4.3.0"
+            },
+            {
+              "nodeId": "System.ComponentModel@4.3.0"
+            },
+            {
+              "nodeId": "System.ComponentModel.TypeConverter@4.3.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.TraceSource@4.3.0"
+            },
+            {
+              "nodeId": "System.Dynamic.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Emit@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.TypeExtensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Xml.XmlDocument@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "NETStandard.Library@1.6.1",
+          "pkgId": "NETStandard.Library@1.6.1",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0"
+            },
+            {
+              "nodeId": "Microsoft.Win32.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.AppContext@4.3.0"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0"
+            },
+            {
+              "nodeId": "System.Collections.Concurrent@4.3.0"
+            },
+            {
+              "nodeId": "System.Console@4.3.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Tools@4.3.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.Tracing@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization.Calendars@4.3.0"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.Compression@4.3.0"
+            },
+            {
+              "nodeId": "System.IO.Compression.ZipFile@4.3.0"
+            },
+            {
+              "nodeId": "System.IO.FileSystem@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.FileSystem.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Linq@4.3.0"
+            },
+            {
+              "nodeId": "System.Linq.Expressions@4.3.0"
+            },
+            {
+              "nodeId": "System.Net.Http@4.3.0"
+            },
+            {
+              "nodeId": "System.Net.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Net.Sockets@4.3.0"
+            },
+            {
+              "nodeId": "System.ObjectModel@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices.RuntimeInformation@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Numerics@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Algorithms@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.X509Certificates@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.RegularExpressions@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Timer@4.3.0"
+            },
+            {
+              "nodeId": "System.Xml.ReaderWriter@4.3.0"
+            },
+            {
+              "nodeId": "System.Xml.XDocument@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.NETCore.Platforms@1.1.0",
+          "pkgId": "Microsoft.NETCore.Platforms@1.1.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Win32.Primitives@4.3.0",
+          "pkgId": "Microsoft.Win32.Primitives@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned",
+          "pkgId": "Microsoft.NETCore.Platforms@1.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.NETCore.Targets@1.1.0",
+          "pkgId": "Microsoft.NETCore.Targets@1.1.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Runtime@4.3.0",
+          "pkgId": "System.Runtime@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned",
+          "pkgId": "Microsoft.NETCore.Targets@1.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.AppContext@4.3.0",
+          "pkgId": "System.AppContext@7.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Runtime@4.3.0:pruned",
+          "pkgId": "System.Runtime@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Collections@4.3.0",
+          "pkgId": "System.Collections@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Collections.Concurrent@4.3.0",
+          "pkgId": "System.Collections.Concurrent@7.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.Tracing@4.3.0"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Collections@4.3.0:pruned",
+          "pkgId": "System.Collections@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Diagnostics.Debug@4.3.0",
+          "pkgId": "System.Diagnostics.Debug@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Diagnostics.Tracing@4.3.0",
+          "pkgId": "System.Diagnostics.Tracing@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Globalization@4.3.0",
+          "pkgId": "System.Globalization@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection@4.3.0",
+          "pkgId": "System.Reflection@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.IO@4.3.0",
+          "pkgId": "System.IO@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Text.Encoding@4.3.0",
+          "pkgId": "System.Text.Encoding@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Threading.Tasks@4.3.0",
+          "pkgId": "System.Threading.Tasks@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.Primitives@4.3.0",
+          "pkgId": "System.Reflection.Primitives@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Resources.ResourceManager@4.3.0",
+          "pkgId": "System.Resources.ResourceManager@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Globalization@4.3.0:pruned",
+          "pkgId": "System.Globalization@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Reflection@4.3.0:pruned",
+          "pkgId": "System.Reflection@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Runtime.Extensions@4.3.0",
+          "pkgId": "System.Runtime.Extensions@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Threading@4.3.0",
+          "pkgId": "System.Threading@7.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Threading.Tasks@4.3.0:pruned",
+          "pkgId": "System.Threading.Tasks@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Console@4.3.0",
+          "pkgId": "System.Console@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.IO@4.3.0:pruned",
+          "pkgId": "System.IO@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Text.Encoding@4.3.0:pruned",
+          "pkgId": "System.Text.Encoding@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Diagnostics.Debug@4.3.0:pruned",
+          "pkgId": "System.Diagnostics.Debug@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Diagnostics.Tools@4.3.0",
+          "pkgId": "System.Diagnostics.Tools@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Diagnostics.Tracing@4.3.0:pruned",
+          "pkgId": "System.Diagnostics.Tracing@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Globalization.Calendars@4.3.0",
+          "pkgId": "System.Globalization.Calendars@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.IO.Compression@4.3.0",
+          "pkgId": "System.IO.Compression@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Buffers@4.3.0"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0:pruned"
+            },
+            {
+              "nodeId": "runtime.native.System@4.3.0"
+            },
+            {
+              "nodeId": "runtime.native.System.IO.Compression@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Buffers@4.3.0",
+          "pkgId": "System.Buffers@7.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Tracing@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Resources.ResourceManager@4.3.0:pruned",
+          "pkgId": "System.Resources.ResourceManager@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Threading@4.3.0:pruned",
+          "pkgId": "System.Threading@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Runtime.Extensions@4.3.0:pruned",
+          "pkgId": "System.Runtime.Extensions@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Runtime.Handles@4.3.0",
+          "pkgId": "System.Runtime.Handles@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Runtime.InteropServices@4.3.0",
+          "pkgId": "System.Runtime.InteropServices@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.Primitives@4.3.0:pruned",
+          "pkgId": "System.Reflection.Primitives@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Runtime.Handles@4.3.0:pruned",
+          "pkgId": "System.Runtime.Handles@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "runtime.native.System@4.3.0",
+          "pkgId": "runtime.native.System@4.3.0",
+          "deps": []
+        },
+        {
+          "nodeId": "runtime.native.System.IO.Compression@4.3.0",
+          "pkgId": "runtime.native.System.IO.Compression@4.3.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.IO.Compression.ZipFile@4.3.0",
+          "pkgId": "System.IO.Compression.ZipFile@7.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Buffers@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.Compression@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.FileSystem@4.3.0"
+            },
+            {
+              "nodeId": "System.IO.FileSystem.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Buffers@4.3.0:pruned",
+          "pkgId": "System.Buffers@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.IO.Compression@4.3.0:pruned",
+          "pkgId": "System.IO.Compression@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.IO.FileSystem@4.3.0",
+          "pkgId": "System.IO.FileSystem@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.FileSystem.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.IO.FileSystem.Primitives@4.3.0",
+          "pkgId": "System.IO.FileSystem.Primitives@7.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.IO.FileSystem.Primitives@4.3.0:pruned",
+          "pkgId": "System.IO.FileSystem.Primitives@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.IO.FileSystem@4.3.0:pruned",
+          "pkgId": "System.IO.FileSystem@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Linq@4.3.0",
+          "pkgId": "System.Linq@7.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Linq.Expressions@4.3.0",
+          "pkgId": "System.Linq.Expressions@7.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Linq@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.ObjectModel@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Emit@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.Emit.ILGeneration@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Emit.Lightweight@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.TypeExtensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Linq@4.3.0:pruned",
+          "pkgId": "System.Linq@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.ObjectModel@4.3.0",
+          "pkgId": "System.ObjectModel@7.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.Emit@4.3.0",
+          "pkgId": "System.Reflection.Emit@7.0.0",
+          "deps": [
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Emit.ILGeneration@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.Emit.ILGeneration@4.3.0",
+          "pkgId": "System.Reflection.Emit.ILGeneration@7.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.Emit.ILGeneration@4.3.0:pruned",
+          "pkgId": "System.Reflection.Emit.ILGeneration@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Reflection.Emit.Lightweight@4.3.0",
+          "pkgId": "System.Reflection.Emit.Lightweight@7.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Emit.ILGeneration@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.Extensions@4.3.0",
+          "pkgId": "System.Reflection.Extensions@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.TypeExtensions@4.3.0",
+          "pkgId": "System.Reflection.TypeExtensions@7.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Net.Http@4.3.0",
+          "pkgId": "System.Net.Http@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.DiagnosticSource@4.3.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.Tracing@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.FileSystem@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Net.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Algorithms@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.OpenSsl@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.X509Certificates@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0:pruned"
+            },
+            {
+              "nodeId": "runtime.native.System@4.3.0:pruned"
+            },
+            {
+              "nodeId": "runtime.native.System.Net.Http@4.3.0:pruned"
+            },
+            {
+              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Diagnostics.DiagnosticSource@4.3.0",
+          "pkgId": "System.Diagnostics.DiagnosticSource@7.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Tracing@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Globalization.Extensions@4.3.0",
+          "pkgId": "System.Globalization.Extensions@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Runtime.InteropServices@4.3.0:pruned",
+          "pkgId": "System.Runtime.InteropServices@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Net.Primitives@4.3.0",
+          "pkgId": "System.Net.Primitives@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Algorithms@4.3.0",
+          "pkgId": "System.Security.Cryptography.Algorithms@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Numerics@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "runtime.native.System.Security.Cryptography.Apple@4.3.0"
+            },
+            {
+              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Runtime.Numerics@4.3.0",
+          "pkgId": "System.Runtime.Numerics@7.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Encoding@4.3.0",
+          "pkgId": "System.Security.Cryptography.Encoding@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Collections.Concurrent@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Linq@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Collections.Concurrent@4.3.0:pruned",
+          "pkgId": "System.Collections.Concurrent@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Primitives@4.3.0",
+          "pkgId": "System.Security.Cryptography.Primitives@7.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+          "pkgId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned",
+          "pkgId": "System.Security.Cryptography.Primitives@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "runtime.native.System.Security.Cryptography.Apple@4.3.0",
+          "pkgId": "runtime.native.System.Security.Cryptography.Apple@4.3.0",
+          "deps": []
+        },
+        {
+          "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned",
+          "pkgId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Encoding@4.3.0:pruned",
+          "pkgId": "System.Security.Cryptography.Encoding@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Security.Cryptography.OpenSsl@4.3.0",
+          "pkgId": "System.Security.Cryptography.OpenSsl@7.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Numerics@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Algorithms@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Runtime.Numerics@4.3.0:pruned",
+          "pkgId": "System.Runtime.Numerics@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Algorithms@4.3.0:pruned",
+          "pkgId": "System.Security.Cryptography.Algorithms@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Security.Cryptography.X509Certificates@4.3.0",
+          "pkgId": "System.Security.Cryptography.X509Certificates@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization.Calendars@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.FileSystem@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.FileSystem.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Numerics@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Algorithms@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Cng@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Csp@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.OpenSsl@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            },
+            {
+              "nodeId": "runtime.native.System@4.3.0:pruned"
+            },
+            {
+              "nodeId": "runtime.native.System.Net.Http@4.3.0"
+            },
+            {
+              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Globalization.Calendars@4.3.0:pruned",
+          "pkgId": "System.Globalization.Calendars@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Cng@4.3.0",
+          "pkgId": "System.Security.Cryptography.Cng@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Algorithms@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Csp@4.3.0",
+          "pkgId": "System.Security.Cryptography.Csp@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Algorithms@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Security.Cryptography.OpenSsl@4.3.0:pruned",
+          "pkgId": "System.Security.Cryptography.OpenSsl@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "runtime.native.System@4.3.0:pruned",
+          "pkgId": "runtime.native.System@4.3.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "runtime.native.System.Net.Http@4.3.0",
+          "pkgId": "runtime.native.System.Net.Http@4.3.0",
+          "deps": []
+        },
+        {
+          "nodeId": "runtime.native.System.Net.Http@4.3.0:pruned",
+          "pkgId": "runtime.native.System.Net.Http@4.3.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Net.Primitives@4.3.0:pruned",
+          "pkgId": "System.Net.Primitives@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Net.Sockets@4.3.0",
+          "pkgId": "System.Net.Sockets@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Net.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.ObjectModel@4.3.0:pruned",
+          "pkgId": "System.ObjectModel@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Reflection.Extensions@4.3.0:pruned",
+          "pkgId": "System.Reflection.Extensions@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Runtime.InteropServices.RuntimeInformation@4.3.0",
+          "pkgId": "System.Runtime.InteropServices.RuntimeInformation@7.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            },
+            {
+              "nodeId": "runtime.native.System@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Security.Cryptography.X509Certificates@4.3.0:pruned",
+          "pkgId": "System.Security.Cryptography.X509Certificates@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Text.Encoding.Extensions@4.3.0",
+          "pkgId": "System.Text.Encoding.Extensions@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Text.RegularExpressions@4.3.0",
+          "pkgId": "System.Text.RegularExpressions@7.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Threading.Timer@4.3.0",
+          "pkgId": "System.Threading.Timer@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Xml.ReaderWriter@4.3.0",
+          "pkgId": "System.Xml.ReaderWriter@7.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.FileSystem@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.FileSystem.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.RegularExpressions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks.Extensions@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Text.Encoding.Extensions@4.3.0:pruned",
+          "pkgId": "System.Text.Encoding.Extensions@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Text.RegularExpressions@4.3.0:pruned",
+          "pkgId": "System.Text.RegularExpressions@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Threading.Tasks.Extensions@4.3.0",
+          "pkgId": "System.Threading.Tasks.Extensions@7.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Xml.XDocument@4.3.0",
+          "pkgId": "System.Xml.XDocument@7.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Tools@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Xml.ReaderWriter@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Diagnostics.Tools@4.3.0:pruned",
+          "pkgId": "System.Diagnostics.Tools@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Xml.ReaderWriter@4.3.0:pruned",
+          "pkgId": "System.Xml.ReaderWriter@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Collections.Specialized@4.3.0",
+          "pkgId": "System.Collections.Specialized@7.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections.NonGeneric@4.3.0"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Collections.NonGeneric@4.3.0",
+          "pkgId": "System.Collections.NonGeneric@7.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Globalization.Extensions@4.3.0:pruned",
+          "pkgId": "System.Globalization.Extensions@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.ComponentModel@4.3.0",
+          "pkgId": "System.ComponentModel@7.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.ComponentModel.TypeConverter@4.3.0",
+          "pkgId": "System.ComponentModel.TypeConverter@7.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Collections.NonGeneric@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Collections.Specialized@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.ComponentModel@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.ComponentModel.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Linq@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.TypeExtensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Collections.NonGeneric@4.3.0:pruned",
+          "pkgId": "System.Collections.NonGeneric@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Collections.Specialized@4.3.0:pruned",
+          "pkgId": "System.Collections.Specialized@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.ComponentModel@4.3.0:pruned",
+          "pkgId": "System.ComponentModel@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.ComponentModel.Primitives@4.3.0",
+          "pkgId": "System.ComponentModel.Primitives@7.0.0",
+          "deps": [
+            {
+              "nodeId": "System.ComponentModel@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.TypeExtensions@4.3.0:pruned",
+          "pkgId": "System.Reflection.TypeExtensions@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Diagnostics.TraceSource@4.3.0",
+          "pkgId": "System.Diagnostics.TraceSource@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            },
+            {
+              "nodeId": "runtime.native.System@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Dynamic.Runtime@4.3.0",
+          "pkgId": "System.Dynamic.Runtime@7.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Linq@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Linq.Expressions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.ObjectModel@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Emit@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Emit.ILGeneration@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.TypeExtensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Linq.Expressions@4.3.0:pruned",
+          "pkgId": "System.Linq.Expressions@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Reflection.Emit@4.3.0:pruned",
+          "pkgId": "System.Reflection.Emit@7.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Xml.XmlDocument@4.3.0",
+          "pkgId": "System.Xml.XmlDocument@7.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Xml.ReaderWriter@4.3.0:pruned"
+            }
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/test/fixtures/props/build-props/App/obj/project.assets.json
+++ b/test/fixtures/props/build-props/App/obj/project.assets.json
@@ -7797,9 +7797,7 @@
     }
   },
   "projectFileDependencyGroups": {
-    "net7.0": [
-      "NSubstitute >= 4.3.0"
-    ]
+    "net7.0": ["NSubstitute >= 4.3.0"]
   },
   "packageFolders": {
     "/Users/kasparmoss/.nuget/packages/": {}
@@ -7829,9 +7827,7 @@
         }
       },
       "warningProperties": {
-        "warnAsError": [
-          "NU1605"
-        ]
+        "warnAsError": ["NU1605"]
       }
     },
     "frameworks": {

--- a/test/fixtures/props/build-props/App/obj/project.assets.json
+++ b/test/fixtures/props/build-props/App/obj/project.assets.json
@@ -7797,7 +7797,9 @@
     }
   },
   "projectFileDependencyGroups": {
-    "net7.0": ["NSubstitute >= 4.3.0"]
+    "net7.0": [
+      "NSubstitute >= 4.3.0"
+    ]
   },
   "packageFolders": {
     "/Users/kasparmoss/.nuget/packages/": {}
@@ -7827,7 +7829,9 @@
         }
       },
       "warningProperties": {
-        "warnAsError": ["NU1605"]
+        "warnAsError": [
+          "NU1605"
+        ]
       }
     },
     "frameworks": {

--- a/test/parsers/parse-core-v2.spec.ts
+++ b/test/parsers/parse-core-v2.spec.ts
@@ -100,8 +100,7 @@ describe('when generating depGraphs and runtime assemblies using the v2 parser',
       description: 'net472 - with package.assets.json',
       projectPath: './test/fixtures/target-framework/no-dependencies/',
       manifestFile: 'obj/project.assets.json',
-      expectedErrorMessage:
-        /not able to find any supported TargetFrameworks/,
+      expectedErrorMessage: /not able to find any supported TargetFrameworks/,
     },
     {
       description: 'net461 - no package.assets.json',

--- a/test/parsers/parse-core-v2.spec.ts
+++ b/test/parsers/parse-core-v2.spec.ts
@@ -100,21 +100,25 @@ describe('when generating depGraphs and runtime assemblies using the v2 parser',
       description: 'net472 - with package.assets.json',
       projectPath: './test/fixtures/target-framework/no-dependencies/',
       manifestFile: 'obj/project.assets.json',
+      expectedErrorMessage:
+        /not able to find any supported TargetFrameworks/,
     },
     {
       description: 'net461 - no package.assets.json',
       projectPath: './test/fixtures/packages-config/repositories-config/',
       manifestFile: 'project.json',
+      expectedErrorMessage:
+        /runtime resolution flag is currently only supported/,
     },
   ])(
     'does not allow the runtime option to be set on unsupported projects: $description',
-    async ({ projectPath, manifestFile }) => {
+    async ({ projectPath, manifestFile, expectedErrorMessage }) => {
       await expect(
         async () =>
           await plugin.inspect(projectPath, manifestFile, {
             'dotnet-runtime-resolution': true,
           }),
-      ).rejects.toThrow(/runtime resolution flag is currently only supported/);
+      ).rejects.toThrow(expectedErrorMessage);
     },
   );
 });

--- a/test/parsers/parse-core-v2.spec.ts
+++ b/test/parsers/parse-core-v2.spec.ts
@@ -28,7 +28,7 @@ describe('when generating depGraphs and runtime assemblies using the v2 parser',
       targetFramework: undefined,
     },
   ])(
-    'should succeed given a project file and an expected graph for test: $description',
+    'succeeds given a project file and returns a single dependency graph for single-targetFramework projects: $description',
     async ({ projectPath, targetFramework }) => {
       // Run a dotnet restore beforehand, in order to be able to supply a project.assets.json file
       await dotnet.restore(projectPath);
@@ -40,9 +40,11 @@ describe('when generating depGraphs and runtime assemblies using the v2 parser',
         'dotnet-target-framework': targetFramework,
       });
 
-      if (pluginApi.isMultiResult(result)) {
-        throw new Error('received invalid depTree');
+      if (!pluginApi.isMultiResult(result)) {
+        throw new Error('expected a multiResult response from inspection');
       }
+
+      expect(result.scannedProjects.length).toEqual(1);
 
       const expectedGraph = JSON.parse(
         fs.readFileSync(
@@ -50,7 +52,46 @@ describe('when generating depGraphs and runtime assemblies using the v2 parser',
           'utf-8',
         ),
       );
-      expect(result.dependencyGraph?.toJSON()).toEqual(expectedGraph.depGraph);
+      expect(result.scannedProjects[0].depGraph?.toJSON()).toEqual(
+        expectedGraph.depGraph,
+      );
+    },
+  );
+
+  it.each([
+    {
+      description: 'parse dotnet 6.0 and 7.0',
+      projectPath: './test/fixtures/dotnetcore/dotnet_6_and_7',
+      expectedDepGraphs: 2,
+    },
+  ])(
+    'succeeds given a project file and returns multiple dependency graphs for multi-targetFramework projects: $description',
+    async ({ projectPath, expectedDepGraphs }) => {
+      // Run a dotnet restore beforehand, in order to be able to supply a project.assets.json file
+      await dotnet.restore(projectPath);
+
+      const manifestFile = 'obj/project.assets.json';
+
+      const result = await plugin.inspect(projectPath, manifestFile, {
+        'dotnet-runtime-resolution': true,
+      });
+
+      if (!pluginApi.isMultiResult(result)) {
+        throw new Error('expected a multiResult response from inspection');
+      }
+
+      expect(result.scannedProjects.length).toEqual(expectedDepGraphs);
+
+      const expectedGraphs = JSON.parse(
+        fs.readFileSync(
+          path.resolve(projectPath, 'expected_depgraphs.json'),
+          'utf-8',
+        ),
+      );
+
+      result.scannedProjects.forEach((scannedProject, i) => {
+        expect(scannedProject.depGraph?.toJSON()).toEqual(expectedGraphs[i]);
+      });
     },
   );
 


### PR DESCRIPTION
This change hooks up the work that was done in

* https://github.com/snyk/snyk-nuget-plugin/pull/172 and
* https://github.com/snyk/snyk-nuget-plugin/pull/173 and
* https://github.com/snyk/snyk-nuget-plugin/pull/175

and finalizes the return value to be a [MultiProjectResult](https://github.com/snyk/snyk-cli-interface/blob/5379064a85628737ffd5b94b230778d62ce4d7f1/legacy/plugin.ts#L130-L135) instead of a `SingleProjectResult`.

The CLI already supports this out of the box (though I have attempted to do a small [UX improvement](https://github.com/snyk/cli/pull/4914)) - but the isolated builds version will need a slight update.