### PR TITLE
feat: dropping the stdout traversal stuff

### DIFF
--- a/lib/nuget-parser/cli/dotnet.ts
+++ b/lib/nuget-parser/cli/dotnet.ts
@@ -2,6 +2,8 @@ import * as debugModule from 'debug';
 import { CliCommandError } from '../../errors';
 import * as path from 'path';
 import * as subprocess from './subprocess';
+import * as fs from 'fs';
+import * as os from 'os';
 
 const debug = debugModule('snyk');
 
@@ -79,53 +81,18 @@ export async function publish(
     args.push(targetFramework);
   }
 
+  // Define a temporary output dir to use for detecting .dlls to use for runtime version assembly detection.
+  const tempDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), `snyk-nuget-plugin-publish-csharp-`),
+  );
+  args.push('--output');
+  args.push(tempDir);
+
   // The path that contains either some form of project file, or a .sln one.
   // See: https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-publish#arguments
   args.push(projectPath);
 
-  const response = await handle('publish', command, args);
+  await handle('publish', command, args);
 
-  // The default output folder is [project_file_folder]/bin/[configuration]/[framework]/[runtime]/publish/
-  // for a self-contained executable. Specifically determining an output folder with --output is deprecated,
-  // as it leads to unpredictable results for multiple target frameworks and runtimes, so we have to cherry-pick
-  // the folders.
-  // See: https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid.
-  // FIXME: As we're not supporting multiple frameworks all over the place, we have to just take the first one.
-  //  It's probably safe, as runtime dll versions most likely don't differ much across *most* dependencies, but
-  //  OS-specific ones (e.g. crypto) might.
-
-  // Looking for something like <project_name> -> /path/to/<project_name>/bin/Debug/<target_framework>/publish/ on Unix.
-  // We could also just hope Microsoft never changes their naming convention, but I think this is less error-prone,
-  // and will potentially also support multiple target frameworks.
-  const publishDirLine = response.stdout
-    .split(/[\r\n]+/)
-    // Projects that are referring to other local projects in their PackageReference item groups will also be restored
-    // in a chained operation. The project we're interested in will be shown last, thus we reverse it.
-    .reverse()
-    // TODO: For multiple target frameworks, replace `find` with a map or something of that kind to return more than the first.
-    // The first thing to get published ought to be the project's own .dll or .exe file, depending on the architecture.
-    // E.g., something like:
-    // dotnet_6 -> /foo/bar/project/bin/Debug/net6.0/osx-arm64/project_name.dll
-    // Either way, since we're forcing a publish of a self-contained project, all .dlls should be placed there.
-    // PRs are welcome!
-    .find((line) => line.endsWith('.dll') || line.endsWith('.exe'));
-
-  if (!publishDirLine) {
-    const err = `Could not find a valid publish path while reading stdout: ${response.stdout}`;
-    debug(err);
-    throw new CliCommandError(`Unable to find a publish dir: ${err}`);
-  }
-
-  // dotnet_6 -> /foo/bar/project/bin/Debug/net6.0/osx-arm64/project_name.dll will then have the first part removed:
-  const [, publishedDllPath] = publishDirLine.split('->') ?? [];
-  if (!publishedDllPath) {
-    const err = `Could not find a valid publish dir while splitting the line: ${publishDirLine}`;
-    debug(err);
-    throw new CliCommandError(`Unable to find a publish dir: ${err}`);
-  }
-
-  // /foo/bar/project/bin/Debug/net6.0/osx-arm64/project_name.dll will then need to be stripped from a file name,
-  // in order to return just the so-called "publish dir":
-  const dirName = path.dirname(publishedDllPath.trim());
-  return dirName;
+  return tempDir;
 }


### PR DESCRIPTION
The previous `v2` parsing logic did a whole bunch of over engineered magic to determine where the publish dir of the `.dll`s we need.

Just asking `dotnet restore` to define a `--output` should work a bit better 🤦🏻 .