### PR TITLE
feat: [SUP-2193] Transitive dependency fixes for `v2` parsing with missing `RID`s.

### DIFF
--- a/lib/nuget-parser/cli/dotnet.ts
+++ b/lib/nuget-parser/cli/dotnet.ts
@@ -75,6 +75,11 @@ export async function publish(
   // Self-contained: Create all required .dlls for version investigation, don't rely on the environment.
   args.push('--sc');
 
+  // Use the current runtime of whatever platform we are on.
+  // This ensures that .dlls will be packaged containing the runtime assembly versions.
+  // TODO: (OSM-521) if/when we allow this to be dynamic based on user input, remember to change this.
+  args.push('--use-current-runtime');
+
   // If your .csproj file contains multiple <TargetFramework> references, you need to supply which one you want to publish.
   if (targetFramework) {
     args.push('--framework');

--- a/lib/nuget-parser/parsers/dotnet-core-v2-parser.ts
+++ b/lib/nuget-parser/parsers/dotnet-core-v2-parser.ts
@@ -194,7 +194,8 @@ function buildGraph(
 
   const topLevelDepPackages = topLevelDeps.reduce((acc, topLevelDepName) => {
     const nameWithVersion = Object.keys(targetDeps).find((targetDep) =>
-      targetDep.startsWith(topLevelDepName),
+      // Lowercase the comparison, as .csproj <PackageReference>s are not case-sensitive, and can be written however you like.
+        targetDep.toLowerCase().startsWith(topLevelDepName.toLowerCase()),
     );
     if (!nameWithVersion) {
       throw new InvalidManifestError(

--- a/lib/nuget-parser/parsers/dotnet-core-v2-parser.ts
+++ b/lib/nuget-parser/parsers/dotnet-core-v2-parser.ts
@@ -195,7 +195,7 @@ function buildGraph(
   const topLevelDepPackages = topLevelDeps.reduce((acc, topLevelDepName) => {
     const nameWithVersion = Object.keys(targetDeps).find((targetDep) =>
       // Lowercase the comparison, as .csproj <PackageReference>s are not case-sensitive, and can be written however you like.
-        targetDep.toLowerCase().startsWith(topLevelDepName.toLowerCase()),
+      targetDep.toLowerCase().startsWith(topLevelDepName.toLowerCase()),
     );
     if (!nameWithVersion) {
       throw new InvalidManifestError(

--- a/test/runtime-assembly.spec.ts
+++ b/test/runtime-assembly.spec.ts
@@ -44,6 +44,26 @@ describe('when parsing runtime assembly', () => {
       },
     },
     {
+      description: 'a dotnet 6.0 project with missing runtime identifier',
+      project: {
+        name: 'dotnet6.csproj',
+        contents: `
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DeepCloner" Version="0.10.4" />
+  </ItemGroup>
+</Project>
+`,
+      },
+      expected: {
+        'Microsoft.CSharp.dll': '6.0.0',
+      },
+    },
+    {
       description: 'a dotnet standard 2.1 project',
       project: {
         name: 'dotnetstandard21.csproj',


### PR DESCRIPTION
For the `v2` parser, there were situations where the `dotnet publish` would not include all the required runtime `.dll`s in cases where a RID was not defined.

This is a part of the issue we want to solve by also passing on runtime identifiers from the customer's environment, but it's a bit of a bigger picture.

Forcing the `dotnet restore` to use the current runtime will force the published artifact to contain the required `.dll`s which we need to traverse.

* Added a test that provokes the error.
* Added a fix for the `dotnet` cli tool