### PR TITLE
fix: [OSM-797] Remove `runtime.*` natives from depGraph

### DIFF
--- a/lib/nuget-parser/parsers/dotnet-core-v2-parser.ts
+++ b/lib/nuget-parser/parsers/dotnet-core-v2-parser.ts
@@ -17,7 +17,7 @@ interface DotnetPackage {
 }
 
 // Dependencies that starts with these are discarded
-const FILTERED_DEPENDENCY_PREFIX = ['runtime'];
+export const FILTERED_DEPENDENCY_PREFIX = ['runtime'];
 
 // The list of top level dependencies and transitive dependencies differ based on the target runtime we've defined.
 // In the generated dependency file created by the `dotnet` CLI, this is organized by the target framework moniker (TFM).

--- a/lib/nuget-parser/parsers/dotnet-core-v2-parser.ts
+++ b/lib/nuget-parser/parsers/dotnet-core-v2-parser.ts
@@ -17,7 +17,14 @@ interface DotnetPackage {
 }
 
 // Dependencies that starts with these are discarded
-export const FILTERED_DEPENDENCY_PREFIX = ['runtime'];
+export const FILTERED_DEPENDENCY_PREFIX = [
+  // `runtime` and `runtime.native` are a bit of a hot topic, see more https://github.com/dotnet/core/issues/7568.
+  // For our case, we are already creating the correct dependencies and their respective runtime version numbers based
+  // of our runtime resolution logic. So a dependency will already be `System.Net.Http@8.0.0` if running on .NET 8, thus
+  // removing the need for a `runtime.native.System.Net.Http@8.0.0` as well. From our investigation these runtime native
+  // dependencies are causing noise for the customers and are not of interested.
+  'runtime',
+];
 
 // The list of top level dependencies and transitive dependencies differ based on the target runtime we've defined.
 // In the generated dependency file created by the `dotnet` CLI, this is organized by the target framework moniker (TFM).
@@ -71,6 +78,13 @@ function recursivelyPopulateNodes(
     const localVisited = visited || new Set<string>();
     const name = depNode[0];
     const version = depNode[1];
+
+    // Ignore packages with specific prefixes, which for one reason or the other are no interesting and pollutes the
+    // graph. Refer to comments on the individual elements in the ignore list for more information.
+    if (FILTERED_DEPENDENCY_PREFIX.some((prefix) => name.startsWith(prefix))) {
+      debug(`${name} matched a prefix we ignore, not adding to graph`);
+      continue;
+    }
 
     const childNode = {
       ...targetDeps[`${name}/${version}`],
@@ -179,16 +193,6 @@ function buildGraph(
     targetFrameworkDependencies,
   ).reduce((acc, entry) => {
     const [nameWithVersion, pkg] = entry;
-
-    // Ignore packages with specific prefixes, which for one reason or the other are no interesting and pollutes the graph.
-    if (
-      FILTERED_DEPENDENCY_PREFIX.some((prefix) =>
-        nameWithVersion.startsWith(prefix),
-      )
-    ) {
-      return acc;
-    }
-
     return { ...acc, [nameWithVersion]: pkg };
   }, {});
 

--- a/test/fixtures/dotnetcore/dotnet_6/expected_depgraph.json
+++ b/test/fixtures/dotnetcore/dotnet_6/expected_depgraph.json
@@ -209,20 +209,6 @@
         }
       },
       {
-        "id": "runtime.native.System@4.3.0",
-        "info": {
-          "name": "runtime.native.System",
-          "version": "4.3.0"
-        }
-      },
-      {
-        "id": "runtime.native.System.IO.Compression@4.3.0",
-        "info": {
-          "name": "runtime.native.System.IO.Compression",
-          "version": "4.3.0"
-        }
-      },
-      {
         "id": "System.IO.Compression.ZipFile@6.0.0",
         "info": {
           "name": "System.IO.Compression.ZipFile",
@@ -356,20 +342,6 @@
         }
       },
       {
-        "id": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
-        "info": {
-          "name": "runtime.native.System.Security.Cryptography.OpenSsl",
-          "version": "4.3.0"
-        }
-      },
-      {
-        "id": "runtime.native.System.Security.Cryptography.Apple@4.3.0",
-        "info": {
-          "name": "runtime.native.System.Security.Cryptography.Apple",
-          "version": "4.3.0"
-        }
-      },
-      {
         "id": "System.Security.Cryptography.OpenSsl@6.0.0",
         "info": {
           "name": "System.Security.Cryptography.OpenSsl",
@@ -395,13 +367,6 @@
         "info": {
           "name": "System.Security.Cryptography.Csp",
           "version": "6.0.0"
-        }
-      },
-      {
-        "id": "runtime.native.System.Net.Http@4.3.0",
-        "info": {
-          "name": "runtime.native.System.Net.Http",
-          "version": "4.3.0"
         }
       },
       {
@@ -1195,12 +1160,6 @@
             },
             {
               "nodeId": "System.Threading.Tasks@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0"
-            },
-            {
-              "nodeId": "runtime.native.System.IO.Compression@4.3.0"
             }
           ]
         },
@@ -1313,16 +1272,6 @@
               "pruned": "true"
             }
           }
-        },
-        {
-          "nodeId": "runtime.native.System@4.3.0",
-          "pkgId": "runtime.native.System@4.3.0",
-          "deps": []
-        },
-        {
-          "nodeId": "runtime.native.System.IO.Compression@4.3.0",
-          "pkgId": "runtime.native.System.IO.Compression@4.3.0",
-          "deps": []
         },
         {
           "nodeId": "System.IO.Compression.ZipFile@4.3.0",
@@ -1711,15 +1660,6 @@
             },
             {
               "nodeId": "System.Threading.Tasks@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Net.Http@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
             }
           ]
         },
@@ -1835,12 +1775,6 @@
             },
             {
               "nodeId": "System.Text.Encoding@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.Apple@4.3.0"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
             }
           ]
         },
@@ -1898,9 +1832,6 @@
             },
             {
               "nodeId": "System.Text.Encoding@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0"
             }
           ]
         },
@@ -1942,28 +1873,8 @@
           ]
         },
         {
-          "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
-          "pkgId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
-          "deps": []
-        },
-        {
           "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned",
           "pkgId": "System.Security.Cryptography.Primitives@6.0.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
-          "nodeId": "runtime.native.System.Security.Cryptography.Apple@4.3.0",
-          "pkgId": "runtime.native.System.Security.Cryptography.Apple@4.3.0",
-          "deps": []
-        },
-        {
-          "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned",
-          "pkgId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
           "deps": [],
           "info": {
             "labels": {
@@ -2020,9 +1931,6 @@
             },
             {
               "nodeId": "System.Text.Encoding@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
             }
           ]
         },
@@ -2115,15 +2023,6 @@
             },
             {
               "nodeId": "System.Threading@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Net.Http@4.3.0"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
             }
           ]
         },
@@ -2232,31 +2131,6 @@
           }
         },
         {
-          "nodeId": "runtime.native.System@4.3.0:pruned",
-          "pkgId": "runtime.native.System@4.3.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
-          "nodeId": "runtime.native.System.Net.Http@4.3.0",
-          "pkgId": "runtime.native.System.Net.Http@4.3.0",
-          "deps": []
-        },
-        {
-          "nodeId": "runtime.native.System.Net.Http@4.3.0:pruned",
-          "pkgId": "runtime.native.System.Net.Http@4.3.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
           "nodeId": "System.Net.Primitives@4.3.0:pruned",
           "pkgId": "System.Net.Primitives@6.0.0",
           "deps": [],
@@ -2331,9 +2205,6 @@
             },
             {
               "nodeId": "System.Threading@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0:pruned"
             }
           ]
         },
@@ -2740,9 +2611,6 @@
             },
             {
               "nodeId": "System.Threading@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0:pruned"
             }
           ]
         },

--- a/test/fixtures/dotnetcore/dotnet_6_and_7/expected_depgraph.json
+++ b/test/fixtures/dotnetcore/dotnet_6_and_7/expected_depgraph.json
@@ -209,20 +209,6 @@
         }
       },
       {
-        "id": "runtime.native.System@4.3.0",
-        "info": {
-          "name": "runtime.native.System",
-          "version": "4.3.0"
-        }
-      },
-      {
-        "id": "runtime.native.System.IO.Compression@4.3.0",
-        "info": {
-          "name": "runtime.native.System.IO.Compression",
-          "version": "4.3.0"
-        }
-      },
-      {
         "id": "System.IO.Compression.ZipFile@7.0.0",
         "info": {
           "name": "System.IO.Compression.ZipFile",
@@ -356,20 +342,6 @@
         }
       },
       {
-        "id": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
-        "info": {
-          "name": "runtime.native.System.Security.Cryptography.OpenSsl",
-          "version": "4.3.0"
-        }
-      },
-      {
-        "id": "runtime.native.System.Security.Cryptography.Apple@4.3.0",
-        "info": {
-          "name": "runtime.native.System.Security.Cryptography.Apple",
-          "version": "4.3.0"
-        }
-      },
-      {
         "id": "System.Security.Cryptography.OpenSsl@7.0.0",
         "info": {
           "name": "System.Security.Cryptography.OpenSsl",
@@ -395,13 +367,6 @@
         "info": {
           "name": "System.Security.Cryptography.Csp",
           "version": "7.0.0"
-        }
-      },
-      {
-        "id": "runtime.native.System.Net.Http@4.3.0",
-        "info": {
-          "name": "runtime.native.System.Net.Http",
-          "version": "4.3.0"
         }
       },
       {
@@ -1195,12 +1160,6 @@
             },
             {
               "nodeId": "System.Threading.Tasks@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0"
-            },
-            {
-              "nodeId": "runtime.native.System.IO.Compression@4.3.0"
             }
           ]
         },
@@ -1313,16 +1272,6 @@
               "pruned": "true"
             }
           }
-        },
-        {
-          "nodeId": "runtime.native.System@4.3.0",
-          "pkgId": "runtime.native.System@4.3.0",
-          "deps": []
-        },
-        {
-          "nodeId": "runtime.native.System.IO.Compression@4.3.0",
-          "pkgId": "runtime.native.System.IO.Compression@4.3.0",
-          "deps": []
         },
         {
           "nodeId": "System.IO.Compression.ZipFile@4.3.0",
@@ -1711,15 +1660,6 @@
             },
             {
               "nodeId": "System.Threading.Tasks@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Net.Http@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
             }
           ]
         },
@@ -1835,12 +1775,6 @@
             },
             {
               "nodeId": "System.Text.Encoding@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.Apple@4.3.0"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
             }
           ]
         },
@@ -1898,9 +1832,6 @@
             },
             {
               "nodeId": "System.Text.Encoding@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0"
             }
           ]
         },
@@ -1942,28 +1873,8 @@
           ]
         },
         {
-          "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
-          "pkgId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
-          "deps": []
-        },
-        {
           "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned",
           "pkgId": "System.Security.Cryptography.Primitives@7.0.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
-          "nodeId": "runtime.native.System.Security.Cryptography.Apple@4.3.0",
-          "pkgId": "runtime.native.System.Security.Cryptography.Apple@4.3.0",
-          "deps": []
-        },
-        {
-          "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned",
-          "pkgId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
           "deps": [],
           "info": {
             "labels": {
@@ -2020,9 +1931,6 @@
             },
             {
               "nodeId": "System.Text.Encoding@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
             }
           ]
         },
@@ -2115,15 +2023,6 @@
             },
             {
               "nodeId": "System.Threading@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Net.Http@4.3.0"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
             }
           ]
         },
@@ -2232,31 +2131,6 @@
           }
         },
         {
-          "nodeId": "runtime.native.System@4.3.0:pruned",
-          "pkgId": "runtime.native.System@4.3.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
-          "nodeId": "runtime.native.System.Net.Http@4.3.0",
-          "pkgId": "runtime.native.System.Net.Http@4.3.0",
-          "deps": []
-        },
-        {
-          "nodeId": "runtime.native.System.Net.Http@4.3.0:pruned",
-          "pkgId": "runtime.native.System.Net.Http@4.3.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
           "nodeId": "System.Net.Primitives@4.3.0:pruned",
           "pkgId": "System.Net.Primitives@7.0.0",
           "deps": [],
@@ -2331,9 +2205,6 @@
             },
             {
               "nodeId": "System.Threading@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0:pruned"
             }
           ]
         },
@@ -2740,9 +2611,6 @@
             },
             {
               "nodeId": "System.Threading@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0:pruned"
             }
           ]
         },

--- a/test/fixtures/dotnetcore/dotnet_6_and_7/expected_depgraphs.json
+++ b/test/fixtures/dotnetcore/dotnet_6_and_7/expected_depgraphs.json
@@ -209,20 +209,6 @@
         }
       },
       {
-        "id": "runtime.native.System@4.3.0",
-        "info": {
-          "name": "runtime.native.System",
-          "version": "4.3.0"
-        }
-      },
-      {
-        "id": "runtime.native.System.IO.Compression@4.3.0",
-        "info": {
-          "name": "runtime.native.System.IO.Compression",
-          "version": "4.3.0"
-        }
-      },
-      {
         "id": "System.IO.Compression.ZipFile@6.0.0",
         "info": {
           "name": "System.IO.Compression.ZipFile",
@@ -356,20 +342,6 @@
         }
       },
       {
-        "id": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
-        "info": {
-          "name": "runtime.native.System.Security.Cryptography.OpenSsl",
-          "version": "4.3.0"
-        }
-      },
-      {
-        "id": "runtime.native.System.Security.Cryptography.Apple@4.3.0",
-        "info": {
-          "name": "runtime.native.System.Security.Cryptography.Apple",
-          "version": "4.3.0"
-        }
-      },
-      {
         "id": "System.Security.Cryptography.OpenSsl@6.0.0",
         "info": {
           "name": "System.Security.Cryptography.OpenSsl",
@@ -395,13 +367,6 @@
         "info": {
           "name": "System.Security.Cryptography.Csp",
           "version": "6.0.0"
-        }
-      },
-      {
-        "id": "runtime.native.System.Net.Http@4.3.0",
-        "info": {
-          "name": "runtime.native.System.Net.Http",
-          "version": "4.3.0"
         }
       },
       {
@@ -1195,12 +1160,6 @@
             },
             {
               "nodeId": "System.Threading.Tasks@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0"
-            },
-            {
-              "nodeId": "runtime.native.System.IO.Compression@4.3.0"
             }
           ]
         },
@@ -1313,16 +1272,6 @@
               "pruned": "true"
             }
           }
-        },
-        {
-          "nodeId": "runtime.native.System@4.3.0",
-          "pkgId": "runtime.native.System@4.3.0",
-          "deps": []
-        },
-        {
-          "nodeId": "runtime.native.System.IO.Compression@4.3.0",
-          "pkgId": "runtime.native.System.IO.Compression@4.3.0",
-          "deps": []
         },
         {
           "nodeId": "System.IO.Compression.ZipFile@4.3.0",
@@ -1711,15 +1660,6 @@
             },
             {
               "nodeId": "System.Threading.Tasks@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Net.Http@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
             }
           ]
         },
@@ -1835,12 +1775,6 @@
             },
             {
               "nodeId": "System.Text.Encoding@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.Apple@4.3.0"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
             }
           ]
         },
@@ -1898,9 +1832,6 @@
             },
             {
               "nodeId": "System.Text.Encoding@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0"
             }
           ]
         },
@@ -1942,28 +1873,8 @@
           ]
         },
         {
-          "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
-          "pkgId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
-          "deps": []
-        },
-        {
           "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned",
           "pkgId": "System.Security.Cryptography.Primitives@6.0.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
-          "nodeId": "runtime.native.System.Security.Cryptography.Apple@4.3.0",
-          "pkgId": "runtime.native.System.Security.Cryptography.Apple@4.3.0",
-          "deps": []
-        },
-        {
-          "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned",
-          "pkgId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
           "deps": [],
           "info": {
             "labels": {
@@ -2020,9 +1931,6 @@
             },
             {
               "nodeId": "System.Text.Encoding@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
             }
           ]
         },
@@ -2115,15 +2023,6 @@
             },
             {
               "nodeId": "System.Threading@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Net.Http@4.3.0"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
             }
           ]
         },
@@ -2232,31 +2131,6 @@
           }
         },
         {
-          "nodeId": "runtime.native.System@4.3.0:pruned",
-          "pkgId": "runtime.native.System@4.3.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
-          "nodeId": "runtime.native.System.Net.Http@4.3.0",
-          "pkgId": "runtime.native.System.Net.Http@4.3.0",
-          "deps": []
-        },
-        {
-          "nodeId": "runtime.native.System.Net.Http@4.3.0:pruned",
-          "pkgId": "runtime.native.System.Net.Http@4.3.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
           "nodeId": "System.Net.Primitives@4.3.0:pruned",
           "pkgId": "System.Net.Primitives@6.0.0",
           "deps": [],
@@ -2331,9 +2205,6 @@
             },
             {
               "nodeId": "System.Threading@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0:pruned"
             }
           ]
         },
@@ -2740,9 +2611,6 @@
             },
             {
               "nodeId": "System.Threading@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0:pruned"
             }
           ]
         },
@@ -3063,20 +2931,6 @@
         }
       },
       {
-        "id": "runtime.native.System@4.3.0",
-        "info": {
-          "name": "runtime.native.System",
-          "version": "4.3.0"
-        }
-      },
-      {
-        "id": "runtime.native.System.IO.Compression@4.3.0",
-        "info": {
-          "name": "runtime.native.System.IO.Compression",
-          "version": "4.3.0"
-        }
-      },
-      {
         "id": "System.IO.Compression.ZipFile@7.0.0",
         "info": {
           "name": "System.IO.Compression.ZipFile",
@@ -3210,20 +3064,6 @@
         }
       },
       {
-        "id": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
-        "info": {
-          "name": "runtime.native.System.Security.Cryptography.OpenSsl",
-          "version": "4.3.0"
-        }
-      },
-      {
-        "id": "runtime.native.System.Security.Cryptography.Apple@4.3.0",
-        "info": {
-          "name": "runtime.native.System.Security.Cryptography.Apple",
-          "version": "4.3.0"
-        }
-      },
-      {
         "id": "System.Security.Cryptography.OpenSsl@7.0.0",
         "info": {
           "name": "System.Security.Cryptography.OpenSsl",
@@ -3249,13 +3089,6 @@
         "info": {
           "name": "System.Security.Cryptography.Csp",
           "version": "7.0.0"
-        }
-      },
-      {
-        "id": "runtime.native.System.Net.Http@4.3.0",
-        "info": {
-          "name": "runtime.native.System.Net.Http",
-          "version": "4.3.0"
         }
       },
       {
@@ -4049,12 +3882,6 @@
             },
             {
               "nodeId": "System.Threading.Tasks@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0"
-            },
-            {
-              "nodeId": "runtime.native.System.IO.Compression@4.3.0"
             }
           ]
         },
@@ -4167,16 +3994,6 @@
               "pruned": "true"
             }
           }
-        },
-        {
-          "nodeId": "runtime.native.System@4.3.0",
-          "pkgId": "runtime.native.System@4.3.0",
-          "deps": []
-        },
-        {
-          "nodeId": "runtime.native.System.IO.Compression@4.3.0",
-          "pkgId": "runtime.native.System.IO.Compression@4.3.0",
-          "deps": []
         },
         {
           "nodeId": "System.IO.Compression.ZipFile@4.3.0",
@@ -4565,15 +4382,6 @@
             },
             {
               "nodeId": "System.Threading.Tasks@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Net.Http@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
             }
           ]
         },
@@ -4689,12 +4497,6 @@
             },
             {
               "nodeId": "System.Text.Encoding@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.Apple@4.3.0"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
             }
           ]
         },
@@ -4752,9 +4554,6 @@
             },
             {
               "nodeId": "System.Text.Encoding@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0"
             }
           ]
         },
@@ -4796,28 +4595,8 @@
           ]
         },
         {
-          "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
-          "pkgId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
-          "deps": []
-        },
-        {
           "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned",
           "pkgId": "System.Security.Cryptography.Primitives@7.0.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
-          "nodeId": "runtime.native.System.Security.Cryptography.Apple@4.3.0",
-          "pkgId": "runtime.native.System.Security.Cryptography.Apple@4.3.0",
-          "deps": []
-        },
-        {
-          "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned",
-          "pkgId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
           "deps": [],
           "info": {
             "labels": {
@@ -4874,9 +4653,6 @@
             },
             {
               "nodeId": "System.Text.Encoding@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
             }
           ]
         },
@@ -4969,15 +4745,6 @@
             },
             {
               "nodeId": "System.Threading@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Net.Http@4.3.0"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
             }
           ]
         },
@@ -5086,31 +4853,6 @@
           }
         },
         {
-          "nodeId": "runtime.native.System@4.3.0:pruned",
-          "pkgId": "runtime.native.System@4.3.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
-          "nodeId": "runtime.native.System.Net.Http@4.3.0",
-          "pkgId": "runtime.native.System.Net.Http@4.3.0",
-          "deps": []
-        },
-        {
-          "nodeId": "runtime.native.System.Net.Http@4.3.0:pruned",
-          "pkgId": "runtime.native.System.Net.Http@4.3.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
           "nodeId": "System.Net.Primitives@4.3.0:pruned",
           "pkgId": "System.Net.Primitives@7.0.0",
           "deps": [],
@@ -5185,9 +4927,6 @@
             },
             {
               "nodeId": "System.Threading@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0:pruned"
             }
           ]
         },
@@ -5594,9 +5333,6 @@
             },
             {
               "nodeId": "System.Threading@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0:pruned"
             }
           ]
         },

--- a/test/fixtures/dotnetcore/dotnet_6_local_package_reference/proj1/expected_depgraph.json
+++ b/test/fixtures/dotnetcore/dotnet_6_local_package_reference/proj1/expected_depgraph.json
@@ -209,20 +209,6 @@
         }
       },
       {
-        "id": "runtime.native.System@4.3.0",
-        "info": {
-          "name": "runtime.native.System",
-          "version": "4.3.0"
-        }
-      },
-      {
-        "id": "runtime.native.System.IO.Compression@4.3.0",
-        "info": {
-          "name": "runtime.native.System.IO.Compression",
-          "version": "4.3.0"
-        }
-      },
-      {
         "id": "System.IO.Compression.ZipFile@6.0.0",
         "info": {
           "name": "System.IO.Compression.ZipFile",
@@ -356,20 +342,6 @@
         }
       },
       {
-        "id": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
-        "info": {
-          "name": "runtime.native.System.Security.Cryptography.OpenSsl",
-          "version": "4.3.0"
-        }
-      },
-      {
-        "id": "runtime.native.System.Security.Cryptography.Apple@4.3.0",
-        "info": {
-          "name": "runtime.native.System.Security.Cryptography.Apple",
-          "version": "4.3.0"
-        }
-      },
-      {
         "id": "System.Security.Cryptography.OpenSsl@6.0.0",
         "info": {
           "name": "System.Security.Cryptography.OpenSsl",
@@ -395,13 +367,6 @@
         "info": {
           "name": "System.Security.Cryptography.Csp",
           "version": "6.0.0"
-        }
-      },
-      {
-        "id": "runtime.native.System.Net.Http@4.3.0",
-        "info": {
-          "name": "runtime.native.System.Net.Http",
-          "version": "4.3.0"
         }
       },
       {
@@ -1195,12 +1160,6 @@
             },
             {
               "nodeId": "System.Threading.Tasks@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0"
-            },
-            {
-              "nodeId": "runtime.native.System.IO.Compression@4.3.0"
             }
           ]
         },
@@ -1313,16 +1272,6 @@
               "pruned": "true"
             }
           }
-        },
-        {
-          "nodeId": "runtime.native.System@4.3.0",
-          "pkgId": "runtime.native.System@4.3.0",
-          "deps": []
-        },
-        {
-          "nodeId": "runtime.native.System.IO.Compression@4.3.0",
-          "pkgId": "runtime.native.System.IO.Compression@4.3.0",
-          "deps": []
         },
         {
           "nodeId": "System.IO.Compression.ZipFile@4.3.0",
@@ -1711,15 +1660,6 @@
             },
             {
               "nodeId": "System.Threading.Tasks@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Net.Http@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
             }
           ]
         },
@@ -1835,12 +1775,6 @@
             },
             {
               "nodeId": "System.Text.Encoding@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.Apple@4.3.0"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
             }
           ]
         },
@@ -1898,9 +1832,6 @@
             },
             {
               "nodeId": "System.Text.Encoding@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0"
             }
           ]
         },
@@ -1942,28 +1873,8 @@
           ]
         },
         {
-          "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
-          "pkgId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
-          "deps": []
-        },
-        {
           "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned",
           "pkgId": "System.Security.Cryptography.Primitives@6.0.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
-          "nodeId": "runtime.native.System.Security.Cryptography.Apple@4.3.0",
-          "pkgId": "runtime.native.System.Security.Cryptography.Apple@4.3.0",
-          "deps": []
-        },
-        {
-          "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned",
-          "pkgId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
           "deps": [],
           "info": {
             "labels": {
@@ -2020,9 +1931,6 @@
             },
             {
               "nodeId": "System.Text.Encoding@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
             }
           ]
         },
@@ -2115,15 +2023,6 @@
             },
             {
               "nodeId": "System.Threading@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Net.Http@4.3.0"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
             }
           ]
         },
@@ -2232,31 +2131,6 @@
           }
         },
         {
-          "nodeId": "runtime.native.System@4.3.0:pruned",
-          "pkgId": "runtime.native.System@4.3.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
-          "nodeId": "runtime.native.System.Net.Http@4.3.0",
-          "pkgId": "runtime.native.System.Net.Http@4.3.0",
-          "deps": []
-        },
-        {
-          "nodeId": "runtime.native.System.Net.Http@4.3.0:pruned",
-          "pkgId": "runtime.native.System.Net.Http@4.3.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
           "nodeId": "System.Net.Primitives@4.3.0:pruned",
           "pkgId": "System.Net.Primitives@6.0.0",
           "deps": [],
@@ -2331,9 +2205,6 @@
             },
             {
               "nodeId": "System.Threading@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0:pruned"
             }
           ]
         },
@@ -2740,9 +2611,6 @@
             },
             {
               "nodeId": "System.Threading@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0:pruned"
             }
           ]
         },

--- a/test/fixtures/dotnetcore/dotnet_6_no_rid/expected_depgraph.json
+++ b/test/fixtures/dotnetcore/dotnet_6_no_rid/expected_depgraph.json
@@ -202,20 +202,6 @@
         }
       },
       {
-        "id": "runtime.native.System@4.3.0",
-        "info": {
-          "name": "runtime.native.System",
-          "version": "4.3.0"
-        }
-      },
-      {
-        "id": "runtime.native.System.IO.Compression@4.3.0",
-        "info": {
-          "name": "runtime.native.System.IO.Compression",
-          "version": "4.3.0"
-        }
-      },
-      {
         "id": "System.IO.Compression.ZipFile@6.0.0",
         "info": {
           "name": "System.IO.Compression.ZipFile",
@@ -349,20 +335,6 @@
         }
       },
       {
-        "id": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
-        "info": {
-          "name": "runtime.native.System.Security.Cryptography.OpenSsl",
-          "version": "4.3.0"
-        }
-      },
-      {
-        "id": "runtime.native.System.Security.Cryptography.Apple@4.3.0",
-        "info": {
-          "name": "runtime.native.System.Security.Cryptography.Apple",
-          "version": "4.3.0"
-        }
-      },
-      {
         "id": "System.Security.Cryptography.OpenSsl@6.0.0",
         "info": {
           "name": "System.Security.Cryptography.OpenSsl",
@@ -388,13 +360,6 @@
         "info": {
           "name": "System.Security.Cryptography.Csp",
           "version": "6.0.0"
-        }
-      },
-      {
-        "id": "runtime.native.System.Net.Http@4.3.0",
-        "info": {
-          "name": "runtime.native.System.Net.Http",
-          "version": "4.3.0"
         }
       },
       {
@@ -1096,12 +1061,6 @@
             },
             {
               "nodeId": "System.Threading.Tasks@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0"
-            },
-            {
-              "nodeId": "runtime.native.System.IO.Compression@4.3.0"
             }
           ]
         },
@@ -1214,16 +1173,6 @@
               "pruned": "true"
             }
           }
-        },
-        {
-          "nodeId": "runtime.native.System@4.3.0",
-          "pkgId": "runtime.native.System@4.3.0",
-          "deps": []
-        },
-        {
-          "nodeId": "runtime.native.System.IO.Compression@4.3.0",
-          "pkgId": "runtime.native.System.IO.Compression@4.3.0",
-          "deps": []
         },
         {
           "nodeId": "System.IO.Compression.ZipFile@4.3.0",
@@ -1612,15 +1561,6 @@
             },
             {
               "nodeId": "System.Threading.Tasks@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Net.Http@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
             }
           ]
         },
@@ -1736,12 +1676,6 @@
             },
             {
               "nodeId": "System.Text.Encoding@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.Apple@4.3.0"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
             }
           ]
         },
@@ -1799,9 +1733,6 @@
             },
             {
               "nodeId": "System.Text.Encoding@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0"
             }
           ]
         },
@@ -1843,28 +1774,8 @@
           ]
         },
         {
-          "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
-          "pkgId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
-          "deps": []
-        },
-        {
           "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned",
           "pkgId": "System.Security.Cryptography.Primitives@6.0.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
-          "nodeId": "runtime.native.System.Security.Cryptography.Apple@4.3.0",
-          "pkgId": "runtime.native.System.Security.Cryptography.Apple@4.3.0",
-          "deps": []
-        },
-        {
-          "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned",
-          "pkgId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
           "deps": [],
           "info": {
             "labels": {
@@ -1921,9 +1832,6 @@
             },
             {
               "nodeId": "System.Text.Encoding@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
             }
           ]
         },
@@ -2016,15 +1924,6 @@
             },
             {
               "nodeId": "System.Threading@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Net.Http@4.3.0"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
             }
           ]
         },
@@ -2133,31 +2032,6 @@
           }
         },
         {
-          "nodeId": "runtime.native.System@4.3.0:pruned",
-          "pkgId": "runtime.native.System@4.3.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
-          "nodeId": "runtime.native.System.Net.Http@4.3.0",
-          "pkgId": "runtime.native.System.Net.Http@4.3.0",
-          "deps": []
-        },
-        {
-          "nodeId": "runtime.native.System.Net.Http@4.3.0:pruned",
-          "pkgId": "runtime.native.System.Net.Http@4.3.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
           "nodeId": "System.Net.Primitives@4.3.0:pruned",
           "pkgId": "System.Net.Primitives@6.0.0",
           "deps": [],
@@ -2232,9 +2106,6 @@
             },
             {
               "nodeId": "System.Threading@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0:pruned"
             }
           ]
         },

--- a/test/fixtures/props/build-props/App/expected_depgraph.json
+++ b/test/fixtures/props/build-props/App/expected_depgraph.json
@@ -209,20 +209,6 @@
         }
       },
       {
-        "id": "runtime.native.System@4.3.0",
-        "info": {
-          "name": "runtime.native.System",
-          "version": "4.3.0"
-        }
-      },
-      {
-        "id": "runtime.native.System.IO.Compression@4.3.0",
-        "info": {
-          "name": "runtime.native.System.IO.Compression",
-          "version": "4.3.0"
-        }
-      },
-      {
         "id": "System.IO.Compression.ZipFile@7.0.0",
         "info": {
           "name": "System.IO.Compression.ZipFile",
@@ -356,20 +342,6 @@
         }
       },
       {
-        "id": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
-        "info": {
-          "name": "runtime.native.System.Security.Cryptography.OpenSsl",
-          "version": "4.3.0"
-        }
-      },
-      {
-        "id": "runtime.native.System.Security.Cryptography.Apple@4.3.0",
-        "info": {
-          "name": "runtime.native.System.Security.Cryptography.Apple",
-          "version": "4.3.0"
-        }
-      },
-      {
         "id": "System.Security.Cryptography.OpenSsl@7.0.0",
         "info": {
           "name": "System.Security.Cryptography.OpenSsl",
@@ -395,13 +367,6 @@
         "info": {
           "name": "System.Security.Cryptography.Csp",
           "version": "7.0.0"
-        }
-      },
-      {
-        "id": "runtime.native.System.Net.Http@4.3.0",
-        "info": {
-          "name": "runtime.native.System.Net.Http",
-          "version": "4.3.0"
         }
       },
       {
@@ -1195,12 +1160,6 @@
             },
             {
               "nodeId": "System.Threading.Tasks@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0"
-            },
-            {
-              "nodeId": "runtime.native.System.IO.Compression@4.3.0"
             }
           ]
         },
@@ -1313,16 +1272,6 @@
               "pruned": "true"
             }
           }
-        },
-        {
-          "nodeId": "runtime.native.System@4.3.0",
-          "pkgId": "runtime.native.System@4.3.0",
-          "deps": []
-        },
-        {
-          "nodeId": "runtime.native.System.IO.Compression@4.3.0",
-          "pkgId": "runtime.native.System.IO.Compression@4.3.0",
-          "deps": []
         },
         {
           "nodeId": "System.IO.Compression.ZipFile@4.3.0",
@@ -1711,15 +1660,6 @@
             },
             {
               "nodeId": "System.Threading.Tasks@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Net.Http@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
             }
           ]
         },
@@ -1835,12 +1775,6 @@
             },
             {
               "nodeId": "System.Text.Encoding@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.Apple@4.3.0"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
             }
           ]
         },
@@ -1898,9 +1832,6 @@
             },
             {
               "nodeId": "System.Text.Encoding@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0"
             }
           ]
         },
@@ -1942,28 +1873,8 @@
           ]
         },
         {
-          "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
-          "pkgId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
-          "deps": []
-        },
-        {
           "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned",
           "pkgId": "System.Security.Cryptography.Primitives@7.0.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
-          "nodeId": "runtime.native.System.Security.Cryptography.Apple@4.3.0",
-          "pkgId": "runtime.native.System.Security.Cryptography.Apple@4.3.0",
-          "deps": []
-        },
-        {
-          "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned",
-          "pkgId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0",
           "deps": [],
           "info": {
             "labels": {
@@ -2020,9 +1931,6 @@
             },
             {
               "nodeId": "System.Text.Encoding@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
             }
           ]
         },
@@ -2115,15 +2023,6 @@
             },
             {
               "nodeId": "System.Threading@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System.Net.Http@4.3.0"
-            },
-            {
-              "nodeId": "runtime.native.System.Security.Cryptography.OpenSsl@4.3.0:pruned"
             }
           ]
         },
@@ -2232,31 +2131,6 @@
           }
         },
         {
-          "nodeId": "runtime.native.System@4.3.0:pruned",
-          "pkgId": "runtime.native.System@4.3.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
-          "nodeId": "runtime.native.System.Net.Http@4.3.0",
-          "pkgId": "runtime.native.System.Net.Http@4.3.0",
-          "deps": []
-        },
-        {
-          "nodeId": "runtime.native.System.Net.Http@4.3.0:pruned",
-          "pkgId": "runtime.native.System.Net.Http@4.3.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
           "nodeId": "System.Net.Primitives@4.3.0:pruned",
           "pkgId": "System.Net.Primitives@7.0.0",
           "deps": [],
@@ -2331,9 +2205,6 @@
             },
             {
               "nodeId": "System.Threading@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0:pruned"
             }
           ]
         },
@@ -2740,9 +2611,6 @@
             },
             {
               "nodeId": "System.Threading@4.3.0:pruned"
-            },
-            {
-              "nodeId": "runtime.native.System@4.3.0:pruned"
             }
           ]
         },

--- a/test/parsers/parse-core-v2.spec.ts
+++ b/test/parsers/parse-core-v2.spec.ts
@@ -97,9 +97,10 @@ describe('when generating depGraphs and runtime assemblies using the v2 parser',
         ),
       );
 
-      result.scannedProjects.forEach((scannedProject, i) => {
-        expect(scannedProject.depGraph?.toJSON()).toEqual(expectedGraphs[i]);
-      });
+      const toJson = result.scannedProjects.map(
+        (result) => result.depGraph?.toJSON(),
+      );
+      expect(toJson).toEqual(expectedGraphs);
     },
   );
 

--- a/test/parsers/parse-core-v2.spec.ts
+++ b/test/parsers/parse-core-v2.spec.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as plugin from '../../lib';
 import * as dotnet from '../../lib/nuget-parser/cli/dotnet';
 import { legacyPlugin as pluginApi } from '@snyk/cli-interface';
+import { FILTERED_DEPENDENCY_PREFIX } from '../../lib/nuget-parser/parsers/dotnet-core-v2-parser';
 
 describe('when generating depGraphs and runtime assemblies using the v2 parser', () => {
   it.each([
@@ -101,6 +102,32 @@ describe('when generating depGraphs and runtime assemblies using the v2 parser',
       });
     },
   );
+
+  it('does not include ignored packages in the resulting depGraph', async () => {
+    const projectPath = './test/fixtures/dotnetcore/dotnet_6';
+    await dotnet.restore(projectPath);
+    const manifestFile = 'obj/project.assets.json';
+    const result = await plugin.inspect(projectPath, manifestFile, {
+      'dotnet-runtime-resolution': true,
+    });
+
+    if (!pluginApi.isMultiResult(result)) {
+      throw new Error('expected a multiResult response from inspection');
+    }
+
+    const depGraph = result.scannedProjects[0].depGraph;
+
+    // TS doesn't get expect().toBeDefined() and will still complain
+    if (!depGraph) {
+      throw new Error('expected depGraph to be defined');
+    }
+
+    const pkgNames = depGraph.getDepPkgs().map((pkg) => pkg.name);
+    const filteredPkgNames: string[] = pkgNames.filter((pkgName) =>
+      FILTERED_DEPENDENCY_PREFIX.some((prefix) => pkgName.startsWith(prefix)),
+    );
+    expect(filteredPkgNames).toEqual([]);
+  });
 
   it.each([
     {


### PR DESCRIPTION
> [They are very noisy and not particularly useful.](https://github.com/dotnet/core/issues/7568)

For our case, we are already creating the correct dependencies and their respective runtime version numbers based of our runtime resolution logic. So a dependency will already be `System.Net.Http@8.0.0` if running on .NET 8, thus removing the need for a `runtime.native.System.Net.Http@8.0.0` as well. From our investigation these runtime native dependencies are causing noise for the customers and are not of interested.

Changes: 
* Added test to reproduce the issue
* Fixed the issue in the `v2` parser
* Updated depGraph fixtures that are now no longer containing the `runtime.*` dependencies