### PR TITLE
feat: [OSM-801] Rewrite of dependency graph generation for `v2` parser

### DIFF
--- a/lib/nuget-parser/index.ts
+++ b/lib/nuget-parser/index.ts
@@ -13,6 +13,7 @@ import {
   DotnetCoreV2Results,
   ManifestType,
   ProjectAssets,
+  PublishedProjectDeps,
   TargetFramework,
   TargetFrameworkInfo,
 } from './types';
@@ -158,12 +159,18 @@ Will attempt to build dependency graph anyway, but the operation might fail.`);
     );
 
     // Then inspect the dependency graph for the runtimepackage's assembly versions.
-    const depsFile = path.resolve(
+    const depsFilePath = path.resolve(
       publishDir,
       `${projectNameFromManifestFile}.deps.json`,
     );
+
+    const depsFile = fs.readFileSync(depsFilePath);
+    const publishedProjectDeps: PublishedProjectDeps = JSON.parse(
+      depsFile.toString('utf-8'),
+    );
+
     const assemblyVersions =
-      runtimeAssembly.generateRuntimeAssemblies(depsFile);
+      runtimeAssembly.generateRuntimeAssemblies(publishedProjectDeps);
 
     // Parse the TargetFramework using Nuget.Frameworks itself, instead of trying to reinvent the wheel, thus ensuring
     // we have maximum context to use later when building the depGraph.
@@ -180,6 +187,7 @@ Will attempt to build dependency graph anyway, but the operation might fail.`);
     const depGraph = parser.depParser.parse(
       resolvedProjectName,
       manifest,
+      publishedProjectDeps,
       assemblyVersions,
       targetFrameworkInfo,
     );

--- a/lib/nuget-parser/index.ts
+++ b/lib/nuget-parser/index.ts
@@ -85,16 +85,16 @@ export async function buildDepGraphFromFiles(
   const projectRootFolder = path.resolve(fileContentPath, '../../');
 
   const parser = PARSERS['dotnet-core-v2'];
-  const manifest: ProjectAssets =
+  const projectAssets: ProjectAssets =
     await parser.fileContentParser.parse(fileContent);
 
-  if (!manifest.project?.frameworks) {
+  if (!projectAssets.project?.frameworks) {
     throw new FileNotProcessableError(
       `unable to detect any target framework in manifest file ${safeTargetFile}, a valid one is needed to continue down this path.`,
     );
   }
 
-  const targetFrameworks = Object.keys(manifest.project.frameworks);
+  const targetFrameworks = Object.keys(projectAssets.project.frameworks);
   if (targetFrameworks.length <= 0) {
     throw new FileNotProcessableError(
       `unable to detect a target framework in ${projectRootFolder}, a valid one is needed to continue down this path.`,
@@ -115,7 +115,8 @@ Will attempt to build dependency graph anyway, but the operation might fail.`);
     projectNamePrefix,
   );
 
-  const projectNameFromManifestFile = manifest?.project?.restore?.projectName;
+  const projectNameFromManifestFile =
+    projectAssets?.project?.restore?.projectName;
   if (
     manifestType === ManifestType.DOTNET_CORE &&
     useProjectNameFromAssetsFile
@@ -186,10 +187,9 @@ Will attempt to build dependency graph anyway, but the operation might fail.`);
 
     const depGraph = parser.depParser.parse(
       resolvedProjectName,
-      manifest,
+      projectAssets,
       publishedProjectDeps,
       assemblyVersions,
-      targetFrameworkInfo,
     );
     results.push({
       dependencyGraph: depGraph,

--- a/lib/nuget-parser/parsers/dotnet-core-v2-parser.ts
+++ b/lib/nuget-parser/parsers/dotnet-core-v2-parser.ts
@@ -5,7 +5,6 @@ import {
   AssemblyVersions,
   ProjectAssets,
   PublishedProjectDeps,
-  TargetFrameworkInfo,
 } from '../types';
 import { InvalidManifestError } from '../../errors';
 
@@ -106,7 +105,6 @@ function buildGraph(
   projectAssets: ProjectAssets,
   publishedProjectDeps: PublishedProjectDeps,
   runtimeAssembly: AssemblyVersions,
-  targetFrameworkInfo: TargetFrameworkInfo,
 ): depGraphLib.DepGraph {
   const depGraphBuilder = new DepGraphBuilder(
     { name: 'nuget' },
@@ -195,7 +193,6 @@ export function parse(
   projectAssets: ProjectAssets,
   publishedProjectDeps: PublishedProjectDeps,
   runtimeAssembly: AssemblyVersions,
-  targetFrameworkInfo: TargetFrameworkInfo,
 ): depGraphLib.DepGraph {
   debug('Trying to parse .net core manifest with v2 depGraph builder');
 
@@ -204,7 +201,6 @@ export function parse(
     projectAssets,
     publishedProjectDeps,
     runtimeAssembly,
-    targetFrameworkInfo,
   );
   return result;
 }

--- a/lib/nuget-parser/runtime-assembly.ts
+++ b/lib/nuget-parser/runtime-assembly.ts
@@ -1,6 +1,5 @@
-import { AssemblyVersions } from './types';
+import { AssemblyVersions, PublishedProjectDeps } from './types';
 import * as errors from '../errors/';
-import * as fs from 'fs';
 import { isEmpty } from 'lodash';
 import * as debugModule from 'debug';
 
@@ -25,11 +24,12 @@ interface Versions {
 // See https://natemcmaster.com/blog/2017/12/21/netcore-primitives/ for a good overview.
 // And https://github.com/dotnet/sdk/blob/main/documentation/specs/runtime-configuration-file.md for the official
 // explanation of what the `deps.json` file is doing that we are traversing.
-export function generateRuntimeAssemblies(filePath: string): AssemblyVersions {
-  debug('extracting runtime assemblies from ' + filePath);
+export function generateRuntimeAssemblies(
+  deps: PublishedProjectDeps,
+): AssemblyVersions {
+  const runtimeTargetName = deps.runtimeTarget.name;
 
-  const depsFile = fs.readFileSync(filePath);
-  const deps = JSON.parse(depsFile.toString('utf-8'));
+  debug(`extracting runtime assemblies from ${runtimeTargetName}`);
 
   if (!deps.targets) {
     throw new errors.FileNotProcessableError(
@@ -112,7 +112,7 @@ export function generateRuntimeAssemblies(filePath: string): AssemblyVersions {
     );
   }
 
-  debug('finished extracting runtime assemblies from ' + filePath);
+  debug(`finished extracting runtime assemblies from ${runtimeTargetName}`);
 
   return runtimeAssemblyVersions;
 }

--- a/lib/nuget-parser/types.ts
+++ b/lib/nuget-parser/types.ts
@@ -71,6 +71,13 @@ export interface ProjectAssets {
   project: Project;
 }
 
+// .NET core's published project.deps.json
+export interface PublishedProjectDeps {
+  runtimeTarget: Record<string, any>;
+  targets: Record<string, any>;
+  libraries: Record<string, any>;
+}
+
 // <System.Net.Http, 6.0.0, ...>
 export type AssemblyVersions = Record<string, string>;
 

--- a/test/fixtures/dotnetcore/dotnet_6_local_package_reference/proj1/expected_depgraph.json
+++ b/test/fixtures/dotnetcore/dotnet_6_local_package_reference/proj1/expected_depgraph.json
@@ -480,6 +480,20 @@
           "name": "System.Xml.XmlDocument",
           "version": "6.0.0"
         }
+      },
+      {
+        "id": "proj2@1.0.0",
+        "info": {
+          "name": "proj2",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "System.Text.Encodings.Web@6.0.0",
+        "info": {
+          "name": "System.Text.Encodings.Web",
+          "version": "6.0.0"
+        }
       }
     ],
     "graph": {
@@ -491,6 +505,9 @@
           "deps": [
             {
               "nodeId": "NSubstitute@4.3.0"
+            },
+            {
+              "nodeId": "proj2@1.0.0"
             }
           ]
         },
@@ -2717,6 +2734,20 @@
               "nodeId": "System.Xml.ReaderWriter@4.3.0:pruned"
             }
           ]
+        },
+        {
+          "nodeId": "proj2@1.0.0",
+          "pkgId": "proj2@1.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Text.Encodings.Web@4.7.2"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Text.Encodings.Web@4.7.2",
+          "pkgId": "System.Text.Encodings.Web@6.0.0",
+          "deps": []
         }
       ]
     }

--- a/test/runtime-assembly.spec.ts
+++ b/test/runtime-assembly.spec.ts
@@ -4,6 +4,7 @@ import * as codeGenerator from '../lib/nuget-parser/csharp/generator';
 import * as dotnet from '../lib/nuget-parser/cli/dotnet';
 import * as path from 'path';
 import * as types from '../lib/nuget-parser/types';
+import * as fs from 'fs';
 
 // Include some random C# code that will make `dotnet publish` happy.
 const program: types.DotNetFile = {
@@ -96,8 +97,10 @@ describe('when parsing runtime assembly', () => {
       const projectName = path.parse(project.name).name;
       const assetsFile = path.resolve(publishDir, `${projectName}.deps.json`);
 
-      const runtimeAssemblies =
-        runtimeAssembly.generateRuntimeAssemblies(assetsFile);
+      const depsFile = fs.readFileSync(assetsFile);
+      const deps = JSON.parse(depsFile.toString('utf-8'));
+
+      const runtimeAssemblies = runtimeAssembly.generateRuntimeAssemblies(deps);
 
       expect(runtimeAssemblies).toMatchObject(expected);
 


### PR DESCRIPTION
Thanks to the wonders of beta testing, we've found a much cleaner way to generate the same dependency graph with much less code and more accurate results. Long story short, we were relying way too much on the `assets.json` file over the `deps.json` file.

It was disclosed by a bug that introduced the wrong transitive dependency version.

There is a ton of depGraph tests, and they're all still passing. 🟢 
... except for that one which turned out to be wrong. 😑