### PR TITLE
fix: [OSM-887] Use `targetAlias` where present instead of raw target name

### DIFF
--- a/lib/nuget-parser/index.ts
+++ b/lib/nuget-parser/index.ts
@@ -100,7 +100,6 @@ export async function buildDepGraphFromFiles(
     ([key, value]) => ('targetAlias' in value ? value.targetAlias : key),
   );
 
-  // const targetFrameworks = Object.keys(projectAssets.project.frameworks);
   if (targetFrameworks.length <= 0) {
     throw new FileNotProcessableError(
       `unable to detect a target framework in ${projectRootFolder}, a valid one is needed to continue down this path.`,

--- a/lib/nuget-parser/index.ts
+++ b/lib/nuget-parser/index.ts
@@ -94,7 +94,13 @@ export async function buildDepGraphFromFiles(
     );
   }
 
-  const targetFrameworks = Object.keys(projectAssets.project.frameworks);
+  // Scan all 'frameworks' detected in the project.assets.json file, and use the targetAlias if detected and
+  // otherwise the raw key name, as it's not guaranteed that all framework objects contains a targetAlias.
+  const targetFrameworks = Object.entries(projectAssets.project.frameworks).map(
+    ([key, value]) => ('targetAlias' in value ? value.targetAlias : key),
+  );
+
+  // const targetFrameworks = Object.keys(projectAssets.project.frameworks);
   if (targetFrameworks.length <= 0) {
     throw new FileNotProcessableError(
       `unable to detect a target framework in ${projectRootFolder}, a valid one is needed to continue down this path.`,

--- a/test/dep-graph.spec.ts
+++ b/test/dep-graph.spec.ts
@@ -249,7 +249,7 @@ class TestFixture {
 <Project Sdk='Microsoft.NET.Sdk'>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <!-- Writes the targetFramework name as net7.0-windows7.0 in the assets file,  which the rest of the ecosystem
+    <!-- Writes the targetFramework name as net7.0-windows7.0 in the assets file, which the rest of the ecosystem
      doesn't understand. The generated assets file will name the targetAlias net7.0-windows, which we should pick up. -->
     <TargetFramework>net7.0-windows</TargetFramework>
   </PropertyGroup>


### PR DESCRIPTION
Adding a target framework as

```
<TargetFramework>net7.0-windows</TargetFramework>
```

Will render the framework name in `project.assets.json` as

```json
{
  "version": 3,
  "targets": {
    "net7.0-windows7.0": {
      "AsyncFixer/1.6.0": {
        "type": "package"
      },
      "IDisposableAnalyzers/4.0.7": {
        "type": "package"
      },
(...)
```

And currently we pick up that target name verbatim as pass it along as a valid target framework. That's not the case, apparently, as the correct target framework ought to be `net7.0-windows`, which the assets file do describe in the frameworks list as a `targetAlias`:

```json
     "frameworks": {
        "net7.0-windows7.0": {
          "targetAlias": "net7.0-windows",
          "projectReferences": {
(...)
```

So this PR changes the list of targetFrameworks we work with to use the alias if detected, key name otherwise.