### PR TITLE
fix: [SUP-2195] better error handling of malformed packages.config

### DIFF
--- a/test/fixtures/packages-config/malformed/packages.config
+++ b/test/fixtures/packages-config/malformed/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <package id="Braintree" version="3.3.0" targetFramework="net452" />
+  <package id="NSubstitute" version="1.9.2.0" targetFramework="net451" />
+</configuration>

--- a/test/inspect.spec.ts
+++ b/test/inspect.spec.ts
@@ -50,6 +50,15 @@ describe('when calling plugin.inspect with various configs', () => {
     },
   );
 
+  it('fails gracefully on malformed packages.config', async () => {
+    const filePath = './test/fixtures/packages-config/malformed/';
+    const manifestFile = 'packages.config';
+
+    await expect(
+      async () => await plugin.inspect(filePath, manifestFile),
+    ).rejects.toThrow('Could not find a <packages> tag');
+  });
+
   it('should parse dotnet-cli project with packages.config only', async () => {
     const packagesConfigOnlyPath =
       './test/fixtures/packages-config/config-only/';


### PR DESCRIPTION
A customer had a malformed `packages.config` that just blew up their pipeline with a traceback instead of a more graceful error.