### PR TITLE
fix: [OSM-998] Performance optimization attempts

### DIFF
--- a/lib/nuget-parser/cli/dotnet.ts
+++ b/lib/nuget-parser/cli/dotnet.ts
@@ -52,7 +52,14 @@ export async function validate() {
 
 export async function restore(projectPath: string): Promise<string> {
   const command = 'dotnet';
-  const args = ['restore', '--no-cache', '--verbosity', 'normal', projectPath];
+  const args = [
+    'restore',
+    // Get a larger amount of debugging information to stdout in case something fails.
+    // Useful for customers to attempt self-debugging before raising support requests.
+    '--verbosity',
+    'normal',
+    projectPath,
+  ];
   const result = await handle('restore', command, args);
 
   // A customer can define a <BaseOutPutPath> that redirects where `dotnet` saves the assets file. This will

--- a/lib/nuget-parser/cli/dotnet.ts
+++ b/lib/nuget-parser/cli/dotnet.ts
@@ -116,8 +116,9 @@ export async function publish(
   const tempDir = fs.mkdtempSync(
     path.join(os.tmpdir(), `snyk-nuget-plugin-publish-csharp-`),
   );
-  args.push('--output');
-  args.push(tempDir);
+  // See https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid#recommended-action
+  // about why we're not using `--output` for this.
+  args.push(`--property:PublishDir=${tempDir}`);
 
   // The path that contains either some form of project file, or a .sln one.
   // See: https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-publish#arguments


### PR DESCRIPTION
We're seeing very slow builds on large .NET projects when running through the cli with `--all-projects`, and there are some inconveniences in this plugin that could probably help alleviate this.

This PR:
* Removes `--no-cache` when doing `dotnet restore`. Not sure why I even added this. Think I wanted to have a clean slate guarantee.
* Drops `--output` in favor of `--property:PublishDir=<dir>` as per https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid#recommended-action suggestions.

The general recommendation is to drop a specified output path all together, but I don't see a trivial way of getting `dotnet` to tell me where it intends to publish by default.