### PR TITLE
fix: [OSM-798] not generating .NET code on each TF iteration

### DIFF
--- a/lib/nuget-parser/parsers/dotnet-core-v2-parser.ts
+++ b/lib/nuget-parser/parsers/dotnet-core-v2-parser.ts
@@ -60,7 +60,7 @@ function recursivelyPopulateNodes(
 
     const childId = `${childNode.name}@${childNode.version}`;
 
-    // If we're looking at a  runtime assembly version for self-contained dlls, overwrite the dependency version
+    // If we're looking at a runtime assembly version for self-contained dlls, overwrite the dependency version
     // we've found in the graph with those from the runtime assembly, as they take precedence.
     let assemblyVersion = version;
     // The RuntimeAssembly type contains the name with a .dll suffix, as this is how .NET represents them in the


### PR DESCRIPTION
If scanning multiple target frameworks, we previously would re-create the .NET code to validate said TargetFrameworks on each iteration.

This just moves it out of the loop.