### PR TITLE
fix: fixing bug where .deps file was placed in a subdir of the publis…

### DIFF
--- a/lib/nuget-parser/cli/dotnet.ts
+++ b/lib/nuget-parser/cli/dotnet.ts
@@ -116,6 +116,7 @@ export async function publish(
   const tempDir = fs.mkdtempSync(
     path.join(os.tmpdir(), `snyk-nuget-plugin-publish-csharp-`),
   );
+
   // See https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid#recommended-action
   // about why we're not using `--output` for this.
   args.push(`--property:PublishDir=${tempDir}`);

--- a/test/fixtures/dotnetcore/dotnet_8_with_azure_functions/README.md
+++ b/test/fixtures/dotnetcore/dotnet_8_with_azure_functions/README.md
@@ -1,0 +1,7 @@
+# dotnet_8_functions_bin_folder
+
+Including a `<PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3"/>` above version 4.x will cause
+a `dotnet publish` to add `/bin` to the publish dir, confusing this logic on where the `.deps` file, containing runtime
+pack information, is located.
+
+See [this thread for more](https://github.com/Azure/azure-functions-vs-build-sdk/issues/518).

--- a/test/fixtures/dotnetcore/dotnet_8_with_azure_functions/dotnet_8_with_azure_functions.csproj
+++ b/test/fixtures/dotnetcore/dotnet_8_with_azure_functions/dotnet_8_with_azure_functions.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.3.0" />
+  </ItemGroup>
+</Project>

--- a/test/fixtures/dotnetcore/dotnet_8_with_azure_functions/expected_depgraph.json
+++ b/test/fixtures/dotnetcore/dotnet_8_with_azure_functions/expected_depgraph.json
@@ -1,0 +1,4043 @@
+{
+  "depGraph": {
+    "schemaVersion": "1.3.0",
+    "pkgManager": {
+      "name": "nuget"
+    },
+    "pkgs": [
+      {
+        "id": "dotnet_8_with_azure_functions@1.0.0",
+        "info": {
+          "name": "dotnet_8_with_azure_functions",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.NET.Sdk.Functions@4.3.0",
+        "info": {
+          "name": "Microsoft.NET.Sdk.Functions",
+          "version": "4.3.0"
+        }
+      },
+      {
+        "id": "Microsoft.Azure.Functions.Analyzers@1.0.0",
+        "info": {
+          "name": "Microsoft.Azure.Functions.Analyzers",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Azure.WebJobs@3.0.32",
+        "info": {
+          "name": "Microsoft.Azure.WebJobs",
+          "version": "3.0.32"
+        }
+      },
+      {
+        "id": "Microsoft.Azure.WebJobs.Core@3.0.32",
+        "info": {
+          "name": "Microsoft.Azure.WebJobs.Core",
+          "version": "3.0.32"
+        }
+      },
+      {
+        "id": "System.ComponentModel.Annotations@8.0.0",
+        "info": {
+          "name": "System.ComponentModel.Annotations",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Diagnostics.TraceSource@8.0.0",
+        "info": {
+          "name": "System.Diagnostics.TraceSource",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.NETCore.Platforms@1.1.1",
+        "info": {
+          "name": "Microsoft.NETCore.Platforms",
+          "version": "1.1.1"
+        }
+      },
+      {
+        "id": "System.Collections@8.0.0",
+        "info": {
+          "name": "System.Collections",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.NETCore.Targets@1.1.3",
+        "info": {
+          "name": "Microsoft.NETCore.Targets",
+          "version": "1.1.3"
+        }
+      },
+      {
+        "id": "System.Runtime@8.0.0",
+        "info": {
+          "name": "System.Runtime",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Diagnostics.Debug@8.0.0",
+        "info": {
+          "name": "System.Diagnostics.Debug",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Globalization@8.0.0",
+        "info": {
+          "name": "System.Globalization",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Resources.ResourceManager@8.0.0",
+        "info": {
+          "name": "System.Resources.ResourceManager",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection@8.0.0",
+        "info": {
+          "name": "System.Reflection",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.IO@8.0.0",
+        "info": {
+          "name": "System.IO",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Text.Encoding@8.0.0",
+        "info": {
+          "name": "System.Text.Encoding",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Threading.Tasks@8.0.0",
+        "info": {
+          "name": "System.Threading.Tasks",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection.Primitives@8.0.0",
+        "info": {
+          "name": "System.Reflection.Primitives",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Runtime.Extensions@8.0.0",
+        "info": {
+          "name": "System.Runtime.Extensions",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Threading@8.0.0",
+        "info": {
+          "name": "System.Threading",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Configuration@2.1.1",
+        "info": {
+          "name": "Microsoft.Extensions.Configuration",
+          "version": "2.1.1"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Configuration.Abstractions@2.2.0",
+        "info": {
+          "name": "Microsoft.Extensions.Configuration.Abstractions",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Primitives@2.2.0",
+        "info": {
+          "name": "Microsoft.Extensions.Primitives",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "System.Memory@8.0.0",
+        "info": {
+          "name": "System.Memory",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Runtime.CompilerServices.Unsafe@8.0.0",
+        "info": {
+          "name": "System.Runtime.CompilerServices.Unsafe",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Configuration.EnvironmentVariables@2.1.0",
+        "info": {
+          "name": "Microsoft.Extensions.Configuration.EnvironmentVariables",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Configuration.Json@2.1.0",
+        "info": {
+          "name": "Microsoft.Extensions.Configuration.Json",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Configuration.FileExtensions@2.1.0",
+        "info": {
+          "name": "Microsoft.Extensions.Configuration.FileExtensions",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.FileProviders.Physical@2.1.0",
+        "info": {
+          "name": "Microsoft.Extensions.FileProviders.Physical",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.FileProviders.Abstractions@2.2.0",
+        "info": {
+          "name": "Microsoft.Extensions.FileProviders.Abstractions",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.FileSystemGlobbing@2.1.0",
+        "info": {
+          "name": "Microsoft.Extensions.FileSystemGlobbing",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "Newtonsoft.Json@13.0.1",
+        "info": {
+          "name": "Newtonsoft.Json",
+          "version": "13.0.1"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Hosting@2.1.0",
+        "info": {
+          "name": "Microsoft.Extensions.Hosting",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.DependencyInjection@2.2.0",
+        "info": {
+          "name": "Microsoft.Extensions.DependencyInjection",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.DependencyInjection.Abstractions@2.2.0",
+        "info": {
+          "name": "Microsoft.Extensions.DependencyInjection.Abstractions",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Hosting.Abstractions@2.2.0",
+        "info": {
+          "name": "Microsoft.Extensions.Hosting.Abstractions",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Logging.Abstractions@2.2.0",
+        "info": {
+          "name": "Microsoft.Extensions.Logging.Abstractions",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Logging@2.1.1",
+        "info": {
+          "name": "Microsoft.Extensions.Logging",
+          "version": "2.1.1"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Configuration.Binder@2.1.1",
+        "info": {
+          "name": "Microsoft.Extensions.Configuration.Binder",
+          "version": "2.1.1"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Options@2.2.0",
+        "info": {
+          "name": "Microsoft.Extensions.Options",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Logging.Configuration@2.1.0",
+        "info": {
+          "name": "Microsoft.Extensions.Logging.Configuration",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Options.ConfigurationExtensions@2.1.0",
+        "info": {
+          "name": "Microsoft.Extensions.Options.ConfigurationExtensions",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "System.Memory.Data@1.0.1",
+        "info": {
+          "name": "System.Memory.Data",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "id": "System.Text.Json@8.0.0",
+        "info": {
+          "name": "System.Text.Json",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Threading.Tasks.Dataflow@8.0.0",
+        "info": {
+          "name": "System.Threading.Tasks.Dataflow",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Azure.WebJobs.Extensions@3.0.6",
+        "info": {
+          "name": "Microsoft.Azure.WebJobs.Extensions",
+          "version": "3.0.6"
+        }
+      },
+      {
+        "id": "Microsoft.Azure.WebJobs.Host.Storage@3.0.14",
+        "info": {
+          "name": "Microsoft.Azure.WebJobs.Host.Storage",
+          "version": "3.0.14"
+        }
+      },
+      {
+        "id": "WindowsAzure.Storage@9.3.1",
+        "info": {
+          "name": "WindowsAzure.Storage",
+          "version": "9.3.1"
+        }
+      },
+      {
+        "id": "NETStandard.Library@1.6.1",
+        "info": {
+          "name": "NETStandard.Library",
+          "version": "1.6.1"
+        }
+      },
+      {
+        "id": "Microsoft.Win32.Primitives@8.0.0",
+        "info": {
+          "name": "Microsoft.Win32.Primitives",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.AppContext@8.0.0",
+        "info": {
+          "name": "System.AppContext",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Collections.Concurrent@8.0.0",
+        "info": {
+          "name": "System.Collections.Concurrent",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Diagnostics.Tracing@8.0.0",
+        "info": {
+          "name": "System.Diagnostics.Tracing",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Console@8.0.0",
+        "info": {
+          "name": "System.Console",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Diagnostics.Tools@8.0.0",
+        "info": {
+          "name": "System.Diagnostics.Tools",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Globalization.Calendars@8.0.0",
+        "info": {
+          "name": "System.Globalization.Calendars",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.IO.Compression@8.0.0",
+        "info": {
+          "name": "System.IO.Compression",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Buffers@8.0.0",
+        "info": {
+          "name": "System.Buffers",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Runtime.Handles@8.0.0",
+        "info": {
+          "name": "System.Runtime.Handles",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Runtime.InteropServices@8.0.0",
+        "info": {
+          "name": "System.Runtime.InteropServices",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.IO.Compression.ZipFile@8.0.0",
+        "info": {
+          "name": "System.IO.Compression.ZipFile",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.IO.FileSystem@8.0.0",
+        "info": {
+          "name": "System.IO.FileSystem",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.IO.FileSystem.Primitives@8.0.0",
+        "info": {
+          "name": "System.IO.FileSystem.Primitives",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Linq@8.0.0",
+        "info": {
+          "name": "System.Linq",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Linq.Expressions@8.0.0",
+        "info": {
+          "name": "System.Linq.Expressions",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.ObjectModel@8.0.0",
+        "info": {
+          "name": "System.ObjectModel",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection.Emit@8.0.0",
+        "info": {
+          "name": "System.Reflection.Emit",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection.Emit.ILGeneration@8.0.0",
+        "info": {
+          "name": "System.Reflection.Emit.ILGeneration",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection.Emit.Lightweight@8.0.0",
+        "info": {
+          "name": "System.Reflection.Emit.Lightweight",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection.Extensions@8.0.0",
+        "info": {
+          "name": "System.Reflection.Extensions",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection.TypeExtensions@8.0.0",
+        "info": {
+          "name": "System.Reflection.TypeExtensions",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Net.Http@8.0.0",
+        "info": {
+          "name": "System.Net.Http",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Diagnostics.DiagnosticSource@8.0.0",
+        "info": {
+          "name": "System.Diagnostics.DiagnosticSource",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Globalization.Extensions@8.0.0",
+        "info": {
+          "name": "System.Globalization.Extensions",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Net.Primitives@8.0.0",
+        "info": {
+          "name": "System.Net.Primitives",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.Algorithms@8.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.Algorithms",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Runtime.Numerics@8.0.0",
+        "info": {
+          "name": "System.Runtime.Numerics",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.Encoding@8.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.Encoding",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.Primitives@8.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.Primitives",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.OpenSsl@8.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.OpenSsl",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.X509Certificates@8.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.X509Certificates",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.Cng@8.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.Cng",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.Csp@8.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.Csp",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Net.Sockets@8.0.0",
+        "info": {
+          "name": "System.Net.Sockets",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Runtime.InteropServices.RuntimeInformation@8.0.0",
+        "info": {
+          "name": "System.Runtime.InteropServices.RuntimeInformation",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Text.Encoding.Extensions@8.0.0",
+        "info": {
+          "name": "System.Text.Encoding.Extensions",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Text.RegularExpressions@8.0.0",
+        "info": {
+          "name": "System.Text.RegularExpressions",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Threading.Timer@8.0.0",
+        "info": {
+          "name": "System.Threading.Timer",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Xml.ReaderWriter@8.0.0",
+        "info": {
+          "name": "System.Xml.ReaderWriter",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Threading.Tasks.Extensions@8.0.0",
+        "info": {
+          "name": "System.Threading.Tasks.Extensions",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Xml.XDocument@8.0.0",
+        "info": {
+          "name": "System.Xml.XDocument",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "ncrontab.signed@3.3.0",
+        "info": {
+          "name": "ncrontab.signed",
+          "version": "3.3.0"
+        }
+      },
+      {
+        "id": "Microsoft.Azure.WebJobs.Extensions.Http@3.2.0",
+        "info": {
+          "name": "Microsoft.Azure.WebJobs.Extensions.Http",
+          "version": "3.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNet.WebApi.Client@5.2.8",
+        "info": {
+          "name": "Microsoft.AspNet.WebApi.Client",
+          "version": "5.2.8"
+        }
+      },
+      {
+        "id": "Newtonsoft.Json.Bson@1.0.1",
+        "info": {
+          "name": "Newtonsoft.Json.Bson",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Http@2.2.2",
+        "info": {
+          "name": "Microsoft.AspNetCore.Http",
+          "version": "2.2.2"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Http.Abstractions@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.Http.Abstractions",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Http.Features@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.Http.Features",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "System.Text.Encodings.Web@8.0.0",
+        "info": {
+          "name": "System.Text.Encodings.Web",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.WebUtilities@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.WebUtilities",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.Net.Http.Headers@2.2.0",
+        "info": {
+          "name": "Microsoft.Net.Http.Headers",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.ObjectPool@2.2.0",
+        "info": {
+          "name": "Microsoft.Extensions.ObjectPool",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Mvc.Formatters.Json@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.Mvc.Formatters.Json",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.JsonPatch@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.JsonPatch",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.CSharp@8.0.0",
+        "info": {
+          "name": "Microsoft.CSharp",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Mvc.Core@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.Mvc.Core",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Authentication.Core@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.Authentication.Core",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Authentication.Abstractions@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.Authentication.Abstractions",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Http.Extensions@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.Http.Extensions",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Authorization.Policy@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.Authorization.Policy",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Authorization@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.Authorization",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Hosting.Abstractions@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.Hosting.Abstractions",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Hosting.Server.Abstractions@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.Hosting.Server.Abstractions",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Mvc.Abstractions@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.Mvc.Abstractions",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Routing.Abstractions@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.Routing.Abstractions",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.ResponseCaching.Abstractions@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.ResponseCaching.Abstractions",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Routing@2.2.2",
+        "info": {
+          "name": "Microsoft.AspNetCore.Routing",
+          "version": "2.2.2"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.DependencyModel@2.1.0",
+        "info": {
+          "name": "Microsoft.Extensions.DependencyModel",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "Microsoft.DotNet.PlatformAbstractions@2.1.0",
+        "info": {
+          "name": "Microsoft.DotNet.PlatformAbstractions",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "System.Dynamic.Runtime@8.0.0",
+        "info": {
+          "name": "System.Dynamic.Runtime",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Mvc.WebApiCompatShim@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.Mvc.WebApiCompatShim",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator@4.0.1",
+        "info": {
+          "name": "Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator",
+          "version": "4.0.1"
+        }
+      },
+      {
+        "id": "System.Runtime.Loader@8.0.0",
+        "info": {
+          "name": "System.Runtime.Loader",
+          "version": "8.0.0"
+        }
+      }
+    ],
+    "graph": {
+      "rootNodeId": "root-node",
+      "nodes": [
+        {
+          "nodeId": "root-node",
+          "pkgId": "dotnet_8_with_azure_functions@1.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NET.Sdk.Functions@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.NET.Sdk.Functions@4.3.0",
+          "pkgId": "Microsoft.NET.Sdk.Functions@4.3.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Azure.Functions.Analyzers@1.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Azure.WebJobs@3.0.32"
+            },
+            {
+              "nodeId": "Microsoft.Azure.WebJobs.Extensions@3.0.6"
+            },
+            {
+              "nodeId": "Microsoft.Azure.WebJobs.Extensions.Http@3.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator@4.0.1"
+            },
+            {
+              "nodeId": "Newtonsoft.Json@13.0.1:pruned"
+            },
+            {
+              "nodeId": "System.Net.Http@4.3.4:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encodings.Web@4.7.2:pruned"
+            },
+            {
+              "nodeId": "System.Text.RegularExpressions@4.3.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Azure.Functions.Analyzers@1.0.0",
+          "pkgId": "Microsoft.Azure.Functions.Analyzers@1.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Azure.WebJobs@3.0.32",
+          "pkgId": "Microsoft.Azure.WebJobs@3.0.32",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Azure.WebJobs.Core@3.0.32"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration@2.1.1"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.EnvironmentVariables@2.1.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Json@2.1.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Hosting@2.1.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging@2.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Configuration@2.1.0"
+            },
+            {
+              "nodeId": "Newtonsoft.Json@13.0.1:pruned"
+            },
+            {
+              "nodeId": "System.Memory.Data@1.0.1"
+            },
+            {
+              "nodeId": "System.Threading.Tasks.Dataflow@4.8.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Azure.WebJobs.Core@3.0.32",
+          "pkgId": "Microsoft.Azure.WebJobs.Core@3.0.32",
+          "deps": [
+            {
+              "nodeId": "System.ComponentModel.Annotations@4.5.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.TraceSource@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.ComponentModel.Annotations@4.5.0",
+          "pkgId": "System.ComponentModel.Annotations@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Diagnostics.TraceSource@4.3.0",
+          "pkgId": "System.Diagnostics.TraceSource@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.NETCore.Platforms@1.1.1",
+          "pkgId": "Microsoft.NETCore.Platforms@1.1.1",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Collections@4.3.0",
+          "pkgId": "System.Collections@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned",
+          "pkgId": "Microsoft.NETCore.Platforms@1.1.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.NETCore.Targets@1.1.3",
+          "pkgId": "Microsoft.NETCore.Targets@1.1.3",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Runtime@4.3.1",
+          "pkgId": "System.Runtime@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned",
+          "pkgId": "Microsoft.NETCore.Targets@1.1.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Diagnostics.Debug@4.3.0",
+          "pkgId": "System.Diagnostics.Debug@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Runtime@4.3.1:pruned",
+          "pkgId": "System.Runtime@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Globalization@4.3.0",
+          "pkgId": "System.Globalization@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Resources.ResourceManager@4.3.0",
+          "pkgId": "System.Resources.ResourceManager@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Globalization@4.3.0:pruned",
+          "pkgId": "System.Globalization@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Reflection@4.3.0",
+          "pkgId": "System.Reflection@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.IO@4.3.0",
+          "pkgId": "System.IO@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Text.Encoding@4.3.0",
+          "pkgId": "System.Text.Encoding@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Threading.Tasks@4.3.0",
+          "pkgId": "System.Threading.Tasks@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.Primitives@4.3.0",
+          "pkgId": "System.Reflection.Primitives@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Runtime.Extensions@4.3.0",
+          "pkgId": "System.Runtime.Extensions@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Threading@4.3.0",
+          "pkgId": "System.Threading@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Threading.Tasks@4.3.0:pruned",
+          "pkgId": "System.Threading.Tasks@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration@2.1.1",
+          "pkgId": "Microsoft.Extensions.Configuration@2.1.1",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@2.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.Abstractions@2.2.0",
+          "pkgId": "Microsoft.Extensions.Configuration.Abstractions@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@2.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Primitives@2.2.0",
+          "pkgId": "Microsoft.Extensions.Primitives@2.2.0",
+          "deps": [
+            {
+              "nodeId": "System.Memory@4.5.1"
+            },
+            {
+              "nodeId": "System.Runtime.CompilerServices.Unsafe@4.5.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Memory@4.5.1",
+          "pkgId": "System.Memory@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Runtime.CompilerServices.Unsafe@4.5.1",
+          "pkgId": "System.Runtime.CompilerServices.Unsafe@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.Abstractions@2.2.0:pruned",
+          "pkgId": "Microsoft.Extensions.Configuration.Abstractions@2.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.EnvironmentVariables@2.1.0",
+          "pkgId": "Microsoft.Extensions.Configuration.EnvironmentVariables@2.1.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration@2.1.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration@2.1.1:pruned",
+          "pkgId": "Microsoft.Extensions.Configuration@2.1.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.Json@2.1.0",
+          "pkgId": "Microsoft.Extensions.Configuration.Json@2.1.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration@2.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.FileExtensions@2.1.0"
+            },
+            {
+              "nodeId": "Newtonsoft.Json@13.0.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.FileExtensions@2.1.0",
+          "pkgId": "Microsoft.Extensions.Configuration.FileExtensions@2.1.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration@2.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.FileProviders.Physical@2.1.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.FileProviders.Physical@2.1.0",
+          "pkgId": "Microsoft.Extensions.FileProviders.Physical@2.1.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.FileProviders.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.FileSystemGlobbing@2.1.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.FileProviders.Abstractions@2.2.0",
+          "pkgId": "Microsoft.Extensions.FileProviders.Abstractions@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@2.2.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Primitives@2.2.0:pruned",
+          "pkgId": "Microsoft.Extensions.Primitives@2.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.FileSystemGlobbing@2.1.0",
+          "pkgId": "Microsoft.Extensions.FileSystemGlobbing@2.1.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Newtonsoft.Json@13.0.1",
+          "pkgId": "Newtonsoft.Json@13.0.1",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Hosting@2.1.0",
+          "pkgId": "Microsoft.Extensions.Hosting@2.1.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration@2.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.FileProviders.Physical@2.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Hosting.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging@2.1.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.DependencyInjection@2.2.0",
+          "pkgId": "Microsoft.Extensions.DependencyInjection@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@2.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@2.2.0",
+          "pkgId": "Microsoft.Extensions.DependencyInjection.Abstractions@2.2.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Extensions.FileProviders.Physical@2.1.0:pruned",
+          "pkgId": "Microsoft.Extensions.FileProviders.Physical@2.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Hosting.Abstractions@2.2.0",
+          "pkgId": "Microsoft.Extensions.Hosting.Abstractions@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.FileProviders.Abstractions@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@2.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@2.2.0:pruned",
+          "pkgId": "Microsoft.Extensions.DependencyInjection.Abstractions@2.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.FileProviders.Abstractions@2.2.0:pruned",
+          "pkgId": "Microsoft.Extensions.FileProviders.Abstractions@2.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Logging.Abstractions@2.2.0",
+          "pkgId": "Microsoft.Extensions.Logging.Abstractions@2.2.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Logging@2.1.1",
+          "pkgId": "Microsoft.Extensions.Logging@2.1.1",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Binder@2.1.1"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@2.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.Binder@2.1.1",
+          "pkgId": "Microsoft.Extensions.Configuration.Binder@2.1.1",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration@2.1.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Logging.Abstractions@2.2.0:pruned",
+          "pkgId": "Microsoft.Extensions.Logging.Abstractions@2.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Options@2.2.0",
+          "pkgId": "Microsoft.Extensions.Options@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@2.2.0:pruned"
+            },
+            {
+              "nodeId": "System.ComponentModel.Annotations@4.5.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.ComponentModel.Annotations@4.5.0:pruned",
+          "pkgId": "System.ComponentModel.Annotations@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Logging@2.1.1:pruned",
+          "pkgId": "Microsoft.Extensions.Logging@2.1.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Logging.Configuration@2.1.0",
+          "pkgId": "Microsoft.Extensions.Logging.Configuration@2.1.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Logging@2.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options.ConfigurationExtensions@2.1.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Options.ConfigurationExtensions@2.1.0",
+          "pkgId": "Microsoft.Extensions.Options.ConfigurationExtensions@2.1.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Binder@2.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@2.2.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.Binder@2.1.1:pruned",
+          "pkgId": "Microsoft.Extensions.Configuration.Binder@2.1.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Options@2.2.0:pruned",
+          "pkgId": "Microsoft.Extensions.Options@2.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Newtonsoft.Json@13.0.1:pruned",
+          "pkgId": "Newtonsoft.Json@13.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Memory.Data@1.0.1",
+          "pkgId": "System.Memory.Data@1.0.1",
+          "deps": [
+            {
+              "nodeId": "System.Text.Json@4.6.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Text.Json@4.6.0",
+          "pkgId": "System.Text.Json@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Threading.Tasks.Dataflow@4.8.0",
+          "pkgId": "System.Threading.Tasks.Dataflow@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Azure.WebJobs.Extensions@3.0.6",
+          "pkgId": "Microsoft.Azure.WebJobs.Extensions@3.0.6",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Azure.WebJobs@3.0.32:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Azure.WebJobs.Host.Storage@3.0.14"
+            },
+            {
+              "nodeId": "ncrontab.signed@3.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Azure.WebJobs@3.0.32:pruned",
+          "pkgId": "Microsoft.Azure.WebJobs@3.0.32",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Azure.WebJobs.Host.Storage@3.0.14",
+          "pkgId": "Microsoft.Azure.WebJobs.Host.Storage@3.0.14",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Azure.WebJobs@3.0.32:pruned"
+            },
+            {
+              "nodeId": "WindowsAzure.Storage@9.3.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "WindowsAzure.Storage@9.3.1",
+          "pkgId": "WindowsAzure.Storage@9.3.1",
+          "deps": [
+            {
+              "nodeId": "NETStandard.Library@1.6.1"
+            },
+            {
+              "nodeId": "Newtonsoft.Json@13.0.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "NETStandard.Library@1.6.1",
+          "pkgId": "NETStandard.Library@1.6.1",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Win32.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.AppContext@4.3.0"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Collections.Concurrent@4.3.0"
+            },
+            {
+              "nodeId": "System.Console@4.3.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Tools@4.3.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.Tracing@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization.Calendars@4.3.0"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.Compression@4.3.0"
+            },
+            {
+              "nodeId": "System.IO.Compression.ZipFile@4.3.0"
+            },
+            {
+              "nodeId": "System.IO.FileSystem@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.FileSystem.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Linq@4.3.0"
+            },
+            {
+              "nodeId": "System.Linq.Expressions@4.3.0"
+            },
+            {
+              "nodeId": "System.Net.Http@4.3.4"
+            },
+            {
+              "nodeId": "System.Net.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Net.Sockets@4.3.0"
+            },
+            {
+              "nodeId": "System.ObjectModel@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices.RuntimeInformation@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Numerics@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Algorithms@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.X509Certificates@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.RegularExpressions@4.3.1"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Timer@4.3.0"
+            },
+            {
+              "nodeId": "System.Xml.ReaderWriter@4.3.0"
+            },
+            {
+              "nodeId": "System.Xml.XDocument@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Win32.Primitives@4.3.0",
+          "pkgId": "Microsoft.Win32.Primitives@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.AppContext@4.3.0",
+          "pkgId": "System.AppContext@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Collections@4.3.0:pruned",
+          "pkgId": "System.Collections@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Collections.Concurrent@4.3.0",
+          "pkgId": "System.Collections.Concurrent@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Tracing@4.3.0"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Diagnostics.Debug@4.3.0:pruned",
+          "pkgId": "System.Diagnostics.Debug@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Diagnostics.Tracing@4.3.0",
+          "pkgId": "System.Diagnostics.Tracing@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection@4.3.0:pruned",
+          "pkgId": "System.Reflection@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Resources.ResourceManager@4.3.0:pruned",
+          "pkgId": "System.Resources.ResourceManager@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Runtime.Extensions@4.3.0:pruned",
+          "pkgId": "System.Runtime.Extensions@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Threading@4.3.0:pruned",
+          "pkgId": "System.Threading@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Console@4.3.0",
+          "pkgId": "System.Console@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.IO@4.3.0:pruned",
+          "pkgId": "System.IO@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Text.Encoding@4.3.0:pruned",
+          "pkgId": "System.Text.Encoding@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Diagnostics.Tools@4.3.0",
+          "pkgId": "System.Diagnostics.Tools@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Diagnostics.Tracing@4.3.0:pruned",
+          "pkgId": "System.Diagnostics.Tracing@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Globalization.Calendars@4.3.0",
+          "pkgId": "System.Globalization.Calendars@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.IO.Compression@4.3.0",
+          "pkgId": "System.IO.Compression@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "System.Buffers@4.5.0"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Buffers@4.5.0",
+          "pkgId": "System.Buffers@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Runtime.Handles@4.3.0",
+          "pkgId": "System.Runtime.Handles@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Runtime.InteropServices@4.3.0",
+          "pkgId": "System.Runtime.InteropServices@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.Primitives@4.3.0:pruned",
+          "pkgId": "System.Reflection.Primitives@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Runtime.Handles@4.3.0:pruned",
+          "pkgId": "System.Runtime.Handles@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.IO.Compression.ZipFile@4.3.0",
+          "pkgId": "System.IO.Compression.ZipFile@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Buffers@4.5.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.Compression@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.FileSystem@4.3.0"
+            },
+            {
+              "nodeId": "System.IO.FileSystem.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Buffers@4.5.0:pruned",
+          "pkgId": "System.Buffers@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.IO.Compression@4.3.0:pruned",
+          "pkgId": "System.IO.Compression@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.IO.FileSystem@4.3.0",
+          "pkgId": "System.IO.FileSystem@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.FileSystem.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.IO.FileSystem.Primitives@4.3.0",
+          "pkgId": "System.IO.FileSystem.Primitives@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.IO.FileSystem.Primitives@4.3.0:pruned",
+          "pkgId": "System.IO.FileSystem.Primitives@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.IO.FileSystem@4.3.0:pruned",
+          "pkgId": "System.IO.FileSystem@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Linq@4.3.0",
+          "pkgId": "System.Linq@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Linq.Expressions@4.3.0",
+          "pkgId": "System.Linq.Expressions@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Linq@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.ObjectModel@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Emit@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.Emit.ILGeneration@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Emit.Lightweight@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.TypeExtensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Linq@4.3.0:pruned",
+          "pkgId": "System.Linq@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.ObjectModel@4.3.0",
+          "pkgId": "System.ObjectModel@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.Emit@4.3.0",
+          "pkgId": "System.Reflection.Emit@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Emit.ILGeneration@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.Emit.ILGeneration@4.3.0",
+          "pkgId": "System.Reflection.Emit.ILGeneration@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.Emit.ILGeneration@4.3.0:pruned",
+          "pkgId": "System.Reflection.Emit.ILGeneration@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Reflection.Emit.Lightweight@4.3.0",
+          "pkgId": "System.Reflection.Emit.Lightweight@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Emit.ILGeneration@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.Extensions@4.3.0",
+          "pkgId": "System.Reflection.Extensions@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.TypeExtensions@4.3.0",
+          "pkgId": "System.Reflection.TypeExtensions@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Net.Http@4.3.4",
+          "pkgId": "System.Net.Http@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.DiagnosticSource@4.5.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.Tracing@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.FileSystem@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Net.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Algorithms@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.OpenSsl@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.X509Certificates@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Diagnostics.DiagnosticSource@4.5.0",
+          "pkgId": "System.Diagnostics.DiagnosticSource@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Globalization.Extensions@4.3.0",
+          "pkgId": "System.Globalization.Extensions@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Runtime.InteropServices@4.3.0:pruned",
+          "pkgId": "System.Runtime.InteropServices@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Net.Primitives@4.3.0",
+          "pkgId": "System.Net.Primitives@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Algorithms@4.3.0",
+          "pkgId": "System.Security.Cryptography.Algorithms@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Numerics@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Runtime.Numerics@4.3.0",
+          "pkgId": "System.Runtime.Numerics@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Encoding@4.3.0",
+          "pkgId": "System.Security.Cryptography.Encoding@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Collections.Concurrent@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Linq@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Collections.Concurrent@4.3.0:pruned",
+          "pkgId": "System.Collections.Concurrent@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Primitives@4.3.0",
+          "pkgId": "System.Security.Cryptography.Primitives@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned",
+          "pkgId": "System.Security.Cryptography.Primitives@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Encoding@4.3.0:pruned",
+          "pkgId": "System.Security.Cryptography.Encoding@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Security.Cryptography.OpenSsl@4.3.0",
+          "pkgId": "System.Security.Cryptography.OpenSsl@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Numerics@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Algorithms@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Runtime.Numerics@4.3.0:pruned",
+          "pkgId": "System.Runtime.Numerics@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Algorithms@4.3.0:pruned",
+          "pkgId": "System.Security.Cryptography.Algorithms@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Security.Cryptography.X509Certificates@4.3.0",
+          "pkgId": "System.Security.Cryptography.X509Certificates@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization.Calendars@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.FileSystem@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.FileSystem.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Numerics@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Algorithms@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Cng@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Csp@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.OpenSsl@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Globalization.Calendars@4.3.0:pruned",
+          "pkgId": "System.Globalization.Calendars@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Cng@4.3.0",
+          "pkgId": "System.Security.Cryptography.Cng@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Algorithms@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Csp@4.3.0",
+          "pkgId": "System.Security.Cryptography.Csp@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Algorithms@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Security.Cryptography.OpenSsl@4.3.0:pruned",
+          "pkgId": "System.Security.Cryptography.OpenSsl@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Net.Primitives@4.3.0:pruned",
+          "pkgId": "System.Net.Primitives@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Net.Sockets@4.3.0",
+          "pkgId": "System.Net.Sockets@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Net.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.ObjectModel@4.3.0:pruned",
+          "pkgId": "System.ObjectModel@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Reflection.Extensions@4.3.0:pruned",
+          "pkgId": "System.Reflection.Extensions@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Runtime.InteropServices.RuntimeInformation@4.3.0",
+          "pkgId": "System.Runtime.InteropServices.RuntimeInformation@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Security.Cryptography.X509Certificates@4.3.0:pruned",
+          "pkgId": "System.Security.Cryptography.X509Certificates@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Text.Encoding.Extensions@4.3.0",
+          "pkgId": "System.Text.Encoding.Extensions@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Text.RegularExpressions@4.3.1",
+          "pkgId": "System.Text.RegularExpressions@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Threading.Timer@4.3.0",
+          "pkgId": "System.Threading.Timer@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Xml.ReaderWriter@4.3.0",
+          "pkgId": "System.Xml.ReaderWriter@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.FileSystem@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.FileSystem.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.RegularExpressions@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks.Extensions@4.5.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Text.Encoding.Extensions@4.3.0:pruned",
+          "pkgId": "System.Text.Encoding.Extensions@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Text.RegularExpressions@4.3.1:pruned",
+          "pkgId": "System.Text.RegularExpressions@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Threading.Tasks.Extensions@4.5.1",
+          "pkgId": "System.Threading.Tasks.Extensions@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Xml.XDocument@4.3.0",
+          "pkgId": "System.Xml.XDocument@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Tools@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Xml.ReaderWriter@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Diagnostics.Tools@4.3.0:pruned",
+          "pkgId": "System.Diagnostics.Tools@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Xml.ReaderWriter@4.3.0:pruned",
+          "pkgId": "System.Xml.ReaderWriter@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "ncrontab.signed@3.3.0",
+          "pkgId": "ncrontab.signed@3.3.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Net.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Azure.WebJobs.Extensions.Http@3.2.0",
+          "pkgId": "Microsoft.Azure.WebJobs.Extensions.Http@3.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.AspNet.WebApi.Client@5.2.8"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Http@2.2.2"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Mvc.Formatters.Json@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Mvc.WebApiCompatShim@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Routing@2.2.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Azure.WebJobs@3.0.32:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNet.WebApi.Client@5.2.8",
+          "pkgId": "Microsoft.AspNet.WebApi.Client@5.2.8",
+          "deps": [
+            {
+              "nodeId": "Newtonsoft.Json@13.0.1:pruned"
+            },
+            {
+              "nodeId": "Newtonsoft.Json.Bson@1.0.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "Newtonsoft.Json.Bson@1.0.1",
+          "pkgId": "Newtonsoft.Json.Bson@1.0.1",
+          "deps": [
+            {
+              "nodeId": "NETStandard.Library@1.6.1:pruned"
+            },
+            {
+              "nodeId": "Newtonsoft.Json@13.0.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "NETStandard.Library@1.6.1:pruned",
+          "pkgId": "NETStandard.Library@1.6.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Http@2.2.2",
+          "pkgId": "Microsoft.AspNetCore.Http@2.2.2",
+          "deps": [
+            {
+              "nodeId": "Microsoft.AspNetCore.Http.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.WebUtilities@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.ObjectPool@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Net.Http.Headers@2.2.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Http.Abstractions@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.Http.Abstractions@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.AspNetCore.Http.Features@2.2.0"
+            },
+            {
+              "nodeId": "System.Text.Encodings.Web@4.7.2"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Http.Features@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.Http.Features@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@2.2.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Text.Encodings.Web@4.7.2",
+          "pkgId": "System.Text.Encodings.Web@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.WebUtilities@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.WebUtilities@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Net.Http.Headers@2.2.0"
+            },
+            {
+              "nodeId": "System.Text.Encodings.Web@4.7.2:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Net.Http.Headers@2.2.0",
+          "pkgId": "Microsoft.Net.Http.Headers@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@2.2.0:pruned"
+            },
+            {
+              "nodeId": "System.Buffers@4.5.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Text.Encodings.Web@4.7.2:pruned",
+          "pkgId": "System.Text.Encodings.Web@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.ObjectPool@2.2.0",
+          "pkgId": "Microsoft.Extensions.ObjectPool@2.2.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Net.Http.Headers@2.2.0:pruned",
+          "pkgId": "Microsoft.Net.Http.Headers@2.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Mvc.Formatters.Json@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.Mvc.Formatters.Json@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.AspNetCore.JsonPatch@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Mvc.Core@2.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.JsonPatch@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.JsonPatch@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.CSharp@4.5.0"
+            },
+            {
+              "nodeId": "Newtonsoft.Json@13.0.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.CSharp@4.5.0",
+          "pkgId": "Microsoft.CSharp@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Mvc.Core@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.Mvc.Core@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.AspNetCore.Authentication.Core@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Authorization.Policy@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Hosting.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Http@2.2.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Http.Extensions@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Mvc.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.ResponseCaching.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Routing@2.2.2"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Routing.Abstractions@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyModel@2.1.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.FileProviders.Abstractions@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@2.2.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.DiagnosticSource@4.5.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks.Extensions@4.5.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Authentication.Core@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.Authentication.Core@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.AspNetCore.Authentication.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Http@2.2.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Http.Extensions@2.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Authentication.Abstractions@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.Authentication.Abstractions@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.AspNetCore.Http.Abstractions@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@2.2.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Http.Abstractions@2.2.0:pruned",
+          "pkgId": "Microsoft.AspNetCore.Http.Abstractions@2.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Http@2.2.2:pruned",
+          "pkgId": "Microsoft.AspNetCore.Http@2.2.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Http.Extensions@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.Http.Extensions@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.AspNetCore.Http.Abstractions@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.FileProviders.Abstractions@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Net.Http.Headers@2.2.0:pruned"
+            },
+            {
+              "nodeId": "System.Buffers@4.5.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Authorization.Policy@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.Authorization.Policy@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.AspNetCore.Authentication.Abstractions@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Authorization@2.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Authentication.Abstractions@2.2.0:pruned",
+          "pkgId": "Microsoft.AspNetCore.Authentication.Abstractions@2.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Authorization@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.Authorization@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@2.2.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Hosting.Abstractions@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.Hosting.Abstractions@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.AspNetCore.Hosting.Server.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Http.Abstractions@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Hosting.Abstractions@2.2.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Hosting.Server.Abstractions@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.Hosting.Server.Abstractions@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.AspNetCore.Http.Features@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@2.2.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Http.Features@2.2.0:pruned",
+          "pkgId": "Microsoft.AspNetCore.Http.Features@2.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Hosting.Abstractions@2.2.0:pruned",
+          "pkgId": "Microsoft.Extensions.Hosting.Abstractions@2.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Http.Extensions@2.2.0:pruned",
+          "pkgId": "Microsoft.AspNetCore.Http.Extensions@2.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Mvc.Abstractions@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.Mvc.Abstractions@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.AspNetCore.Routing.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Net.Http.Headers@2.2.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Routing.Abstractions@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.Routing.Abstractions@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.AspNetCore.Http.Abstractions@2.2.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.ResponseCaching.Abstractions@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.ResponseCaching.Abstractions@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@2.2.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Routing@2.2.2",
+          "pkgId": "Microsoft.AspNetCore.Routing@2.2.2",
+          "deps": [
+            {
+              "nodeId": "Microsoft.AspNetCore.Http.Extensions@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Routing.Abstractions@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.ObjectPool@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@2.2.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Routing.Abstractions@2.2.0:pruned",
+          "pkgId": "Microsoft.AspNetCore.Routing.Abstractions@2.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.ObjectPool@2.2.0:pruned",
+          "pkgId": "Microsoft.Extensions.ObjectPool@2.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.DependencyInjection@2.2.0:pruned",
+          "pkgId": "Microsoft.Extensions.DependencyInjection@2.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.DependencyModel@2.1.0",
+          "pkgId": "Microsoft.Extensions.DependencyModel@2.1.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.DotNet.PlatformAbstractions@2.1.0"
+            },
+            {
+              "nodeId": "Newtonsoft.Json@13.0.1:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Dynamic.Runtime@4.0.11"
+            },
+            {
+              "nodeId": "System.Linq@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.DotNet.PlatformAbstractions@2.1.0",
+          "pkgId": "Microsoft.DotNet.PlatformAbstractions@2.1.0",
+          "deps": [
+            {
+              "nodeId": "System.AppContext@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.FileSystem@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.TypeExtensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices.RuntimeInformation@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.AppContext@4.3.0:pruned",
+          "pkgId": "System.AppContext@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Reflection.TypeExtensions@4.3.0:pruned",
+          "pkgId": "System.Reflection.TypeExtensions@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Runtime.InteropServices.RuntimeInformation@4.3.0:pruned",
+          "pkgId": "System.Runtime.InteropServices.RuntimeInformation@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Dynamic.Runtime@4.0.11",
+          "pkgId": "System.Dynamic.Runtime@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Linq@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Linq.Expressions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.ObjectModel@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Emit@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Emit.ILGeneration@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.TypeExtensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Linq.Expressions@4.3.0:pruned",
+          "pkgId": "System.Linq.Expressions@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Reflection.Emit@4.3.0:pruned",
+          "pkgId": "System.Reflection.Emit@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Diagnostics.DiagnosticSource@4.5.0:pruned",
+          "pkgId": "System.Diagnostics.DiagnosticSource@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Threading.Tasks.Extensions@4.5.1:pruned",
+          "pkgId": "System.Threading.Tasks.Extensions@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Mvc.WebApiCompatShim@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.Mvc.WebApiCompatShim@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.AspNet.WebApi.Client@5.2.8:pruned"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Mvc.Core@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Mvc.Formatters.Json@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.WebUtilities@2.2.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNet.WebApi.Client@5.2.8:pruned",
+          "pkgId": "Microsoft.AspNet.WebApi.Client@5.2.8",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Mvc.Core@2.2.0:pruned",
+          "pkgId": "Microsoft.AspNetCore.Mvc.Core@2.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Mvc.Formatters.Json@2.2.0:pruned",
+          "pkgId": "Microsoft.AspNetCore.Mvc.Formatters.Json@2.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.WebUtilities@2.2.0:pruned",
+          "pkgId": "Microsoft.AspNetCore.WebUtilities@2.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Routing@2.2.2:pruned",
+          "pkgId": "Microsoft.AspNetCore.Routing@2.2.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator@4.0.1",
+          "pkgId": "Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator@4.0.1",
+          "deps": [
+            {
+              "nodeId": "System.Runtime.Loader@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Runtime.Loader@4.3.0",
+          "pkgId": "System.Runtime.Loader@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Net.Http@4.3.4:pruned",
+          "pkgId": "System.Net.Http@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/dotnetcore/dotnet_8_with_azure_functions/program.cs
+++ b/test/fixtures/dotnetcore/dotnet_8_with_azure_functions/program.cs
@@ -1,0 +1,8 @@
+﻿using System;
+class TestFixture {
+    static public void Main(String[] args)
+    {
+      var client = new System.Net.Http.HttpClient();
+      Console.WriteLine("Hello, World!");
+    }
+}

--- a/test/parsers/parse-core-v2.spec.ts
+++ b/test/parsers/parse-core-v2.spec.ts
@@ -51,6 +51,12 @@ describe('when generating depGraphs and runtime assemblies using the v2 parser',
       projectPath: './test/fixtures/dotnetcore/netstandard21',
       targetFramework: undefined,
     },
+    {
+      description:
+        'dotnet project that includes azure functions putting deps file in a /bin subdirectory',
+      projectPath: './test/fixtures/dotnetcore/dotnet_8_with_azure_functions',
+      targetFramework: undefined,
+    },
   ])(
     'succeeds given a project file and returns a single dependency graph for single-targetFramework projects: $description',
     async ({ projectPath, targetFramework }) => {


### PR DESCRIPTION
Including `Microsoft.NET.Sdk.Functions` over version `4.x` caused the publish folder to nest `bin/` before the `.deps` file was written.

This caused our logic to fail, as we're only looking for the file in the root folder, as up until now, this was the standard. See this [thread](https://github.com/Azure/azure-functions-vs-build-sdk/issues/518).

This PR, instead of taking chances, just scans the entire publish-dir for a `.deps` file now.

In virtually all cases this file should be in the root, causing the performance overhead to be negligible. 