### PR TITLE
fix: [OSM-1718] Fix `isPublishable` error on older dotnet versions

### DIFF
--- a/lib/nuget-parser/cli/dotnet.ts
+++ b/lib/nuget-parser/cli/dotnet.ts
@@ -38,12 +38,13 @@ async function handle(
   }
 }
 
-export async function validate() {
+export async function validate(): Promise<string> {
   const command = 'dotnet';
   const args = ['--version'];
 
   try {
-    await handle('version', command, args);
+    const result = await handle('version', command, args);
+    return result.stdout.trim();
   } catch (error: unknown) {
     debug('dotnet tool not found, did you install dotnet core?');
     throw error;


### PR DESCRIPTION
This user-friendly update: https://github.com/snyk/snyk-nuget-plugin/pull/207 was a tad too friendly. Any .NET version other than 8 caused it to fail.

Though I still believe in the power of useful error messages, and the SCM solution will still benefit from this. The alternative is a weird dotnet crash with a missing `.deps` file. 

So this is the compromise.

The CCI runners are already running .NET 8 and thus tests are still passing. The negative case is a bit more cumbersome, as most fixtures targeting .NET 8 will fail with a .NET 7/6 executor.