### PR TITLE
fix: remove isPublishable logic

### DIFF
--- a/lib/nuget-parser/cli/dotnet.ts
+++ b/lib/nuget-parser/cli/dotnet.ts
@@ -51,16 +51,6 @@ export async function validate(): Promise<string> {
   }
 }
 
-export async function getProperty(
-  name: string,
-  projectPath: string,
-): Promise<string> {
-  const command = 'dotnet';
-  const args = ['msbuild', `-getProperty:${name}`, projectPath];
-  const result = await handle('getProperty', command, args);
-  return result.stdout.trim();
-}
-
 export async function restore(projectPath: string): Promise<string> {
   const command = 'dotnet';
   const args = [

--- a/lib/nuget-parser/index.ts
+++ b/lib/nuget-parser/index.ts
@@ -182,8 +182,7 @@ Will attempt to build dependency graph anyway, but the operation might fail.`);
   }
 
   // Ensure `dotnet` is installed on the system or fail trying.
-  const version = await dotnet.validate();
-  const majorVersion = parseInt(version.split('.')[0], 10);
+  await dotnet.validate();
 
   // Write a .NET Framework Parser to a temporary directory for validating TargetFrameworks.
   const nugetFrameworksParserLocation = nugetFrameworksParser.generate();
@@ -192,17 +191,6 @@ Will attempt to build dependency graph anyway, but the operation might fail.`);
   // Loop through all TargetFrameworks supplied and generate a dependency graph for each.
   const results: DotnetCoreV2Results = [];
   for (const decidedTargetFramework of decidedTargetFrameworks) {
-    // Ensure the project can be published. If not, we cannot scan published dependencies, thus cannot read the dependency graph
-    // But don't do it if we're running on anything older than .NET 8. There, the msbuild switch doesn't work.
-    if (majorVersion >= 8) {
-      const property = await dotnet.getProperty('IsPublishable', safeRoot);
-      if (property === 'false') {
-        throw new CliCommandError(
-          `unable to scan project in ${safeRoot} as the project has the MSBuild property IsPublishable set to false. Snyk must be able to publish the solution in order to accurately scan dependencies.`,
-        );
-      }
-    }
-
     // Run `dotnet publish` to create a self-contained publishable binary with included .dlls for assembly version inspection.
     const publishDir = await dotnet.publish(safeRoot, decidedTargetFramework);
 

--- a/test/fixtures/dotnetcore/dotnet_8_unpublishable/dotnet_8_unpublishable.csproj
+++ b/test/fixtures/dotnetcore/dotnet_8_unpublishable/dotnet_8_unpublishable.csproj
@@ -1,6 +1,0 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <IsPublishable>false</IsPublishable>
-  </PropertyGroup>
-</Project>

--- a/test/fixtures/dotnetcore/dotnet_8_unpublishable/program.cs
+++ b/test/fixtures/dotnetcore/dotnet_8_unpublishable/program.cs
@@ -1,8 +1,0 @@
-﻿using System;
-class TestFixture {
-    static public void Main(String[] args)
-    {
-      var client = new System.Net.Http.HttpClient();
-      Console.WriteLine("Hello, World!");
-    }
-}

--- a/test/parsers/parse-core-v2.spec.ts
+++ b/test/parsers/parse-core-v2.spec.ts
@@ -166,14 +166,6 @@ describe('when generating depGraphs and runtime assemblies using the v2 parser',
       expectedErrorMessage:
         /runtime resolution flag is currently only supported/,
     },
-    {
-      description: 'dotnet core project - unpublishable',
-      projectPath: './test/fixtures/dotnetcore/dotnet_8_unpublishable/',
-      manifestFile: 'obj/project.assets.json',
-      requiresRestore: true,
-      expectedErrorMessage:
-        /as the project has the MSBuild property IsPublishable set to false/,
-    },
   ])(
     'does not allow the runtime option to be set on unsupported projects: $description',
     async ({


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

the `isPublishable` was added to make better error messages for users who try to scan a project defined be not publishable.

However, this flag causes issues with older .NET versions. Will be removed until a better solution is in place.
