### PR TITLE
fix: fixed reading wrong deps.json file

### DIFF
--- a/test/fixtures/dotnetcore/dotnet_8_local_package_reference/BaseProj.csproj
+++ b/test/fixtures/dotnetcore/dotnet_8_local_package_reference/BaseProj.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsTestProject>true</IsTestProject>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+  </ItemGroup>
+</Project>

--- a/test/fixtures/dotnetcore/dotnet_8_local_package_reference/SecondaryProj/SecondaryProj.csproj
+++ b/test/fixtures/dotnetcore/dotnet_8_local_package_reference/SecondaryProj/SecondaryProj.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Moq" Version="4.20.70" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BaseProj.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/fixtures/dotnetcore/dotnet_8_local_package_reference/SecondaryProj/expected_depgraph.json
+++ b/test/fixtures/dotnetcore/dotnet_8_local_package_reference/SecondaryProj/expected_depgraph.json
@@ -1,0 +1,184 @@
+{
+  "depGraph": {
+    "schemaVersion": "1.3.0",
+    "pkgManager": {
+      "name": "nuget"
+    },
+    "pkgs": [
+      {
+        "id": "SecondaryProj@1.0.0",
+        "info": {
+          "name": "SecondaryProj",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "BaseProj@1.0.0",
+        "info": {
+          "name": "BaseProj",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.NET.Test.Sdk@17.10.0",
+        "info": {
+          "name": "Microsoft.NET.Test.Sdk",
+          "version": "17.10.0"
+        }
+      },
+      {
+        "id": "Microsoft.CodeCoverage@17.10.0",
+        "info": {
+          "name": "Microsoft.CodeCoverage",
+          "version": "17.10.0"
+        }
+      },
+      {
+        "id": "Microsoft.TestPlatform.TestHost@17.10.0",
+        "info": {
+          "name": "Microsoft.TestPlatform.TestHost",
+          "version": "17.10.0"
+        }
+      },
+      {
+        "id": "Microsoft.TestPlatform.ObjectModel@17.10.0",
+        "info": {
+          "name": "Microsoft.TestPlatform.ObjectModel",
+          "version": "17.10.0"
+        }
+      },
+      {
+        "id": "System.Reflection.Metadata@8.0.0",
+        "info": {
+          "name": "System.Reflection.Metadata",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Newtonsoft.Json@13.0.1",
+        "info": {
+          "name": "Newtonsoft.Json",
+          "version": "13.0.1"
+        }
+      },
+      {
+        "id": "Moq@4.20.70",
+        "info": {
+          "name": "Moq",
+          "version": "4.20.70"
+        }
+      },
+      {
+        "id": "Castle.Core@5.1.1",
+        "info": {
+          "name": "Castle.Core",
+          "version": "5.1.1"
+        }
+      },
+      {
+        "id": "System.Diagnostics.EventLog@6.0.0",
+        "info": {
+          "name": "System.Diagnostics.EventLog",
+          "version": "6.0.0"
+        }
+      }
+    ],
+    "graph": {
+      "rootNodeId": "root-node",
+      "nodes": [
+        {
+          "nodeId": "root-node",
+          "pkgId": "SecondaryProj@1.0.0",
+          "deps": [
+            {
+              "nodeId": "BaseProj@1.0.0"
+            },
+            {
+              "nodeId": "Moq@4.20.70"
+            }
+          ]
+        },
+        {
+          "nodeId": "BaseProj@1.0.0",
+          "pkgId": "BaseProj@1.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NET.Test.Sdk@17.10.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.NET.Test.Sdk@17.10.0",
+          "pkgId": "Microsoft.NET.Test.Sdk@17.10.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.CodeCoverage@17.10.0"
+            },
+            {
+              "nodeId": "Microsoft.TestPlatform.TestHost@17.10.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.CodeCoverage@17.10.0",
+          "pkgId": "Microsoft.CodeCoverage@17.10.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.TestPlatform.TestHost@17.10.0",
+          "pkgId": "Microsoft.TestPlatform.TestHost@17.10.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.TestPlatform.ObjectModel@17.10.0"
+            },
+            {
+              "nodeId": "Newtonsoft.Json@13.0.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.TestPlatform.ObjectModel@17.10.0",
+          "pkgId": "Microsoft.TestPlatform.ObjectModel@17.10.0",
+          "deps": [
+            {
+              "nodeId": "System.Reflection.Metadata@1.6.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.Metadata@1.6.0",
+          "pkgId": "System.Reflection.Metadata@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Newtonsoft.Json@13.0.1",
+          "pkgId": "Newtonsoft.Json@13.0.1",
+          "deps": []
+        },
+        {
+          "nodeId": "Moq@4.20.70",
+          "pkgId": "Moq@4.20.70",
+          "deps": [
+            {
+              "nodeId": "Castle.Core@5.1.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "Castle.Core@5.1.1",
+          "pkgId": "Castle.Core@5.1.1",
+          "deps": [
+            {
+              "nodeId": "System.Diagnostics.EventLog@6.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Diagnostics.EventLog@6.0.0",
+          "pkgId": "System.Diagnostics.EventLog@6.0.0",
+          "deps": []
+        }
+      ]
+    }
+  }
+}

--- a/test/parsers/parse-core-v2.spec.ts
+++ b/test/parsers/parse-core-v2.spec.ts
@@ -91,6 +91,15 @@ describe('when generating depGraphs and runtime assemblies using the v2 parser',
       targetFramework: 'net8.0',
       manifestFilePath: 'obj/project.assets.json',
     },
+    {
+      description:
+        'parse dotnet 8.0 with a local PackageReference to the root project',
+      projectPath:
+        './test/fixtures/dotnetcore/dotnet_8_local_package_reference/SecondaryProj',
+      projectFile: 'SecondaryProj.csproj',
+      targetFramework: 'net8.0',
+      manifestFilePath: 'obj/project.assets.json',
+    },
   ])(
     'succeeds given a project file and returns a single dependency graph for single-targetFramework projects: $description',
     async ({ projectPath, projectFile, manifestFilePath, targetFramework }) => {


### PR DESCRIPTION
In some cases of nested projects, if a subproject references a local one higher in path, `dotnet publish` will generate `.deps.json` files for both projects. The actual logic finds and uses the first `.deps.json` file found, even though it is not for the scanned project.
This PR fixes that bug.

Attached bellow an example of a `.bin` folder for the `SecondaryProj`, generated by `dotnet publish` were the bug can be visualised
![image](https://github.com/user-attachments/assets/7ca1e0a3-dcf2-47cc-b2b7-66acea57408d)
