### PR TITLE
fix: disable PublishSingleFile during snyk scan

### DIFF
--- a/lib/nuget-parser/cli/dotnet.ts
+++ b/lib/nuget-parser/cli/dotnet.ts
@@ -99,14 +99,20 @@ export async function publish(
     path.join(os.tmpdir(), `snyk-nuget-plugin-publish-csharp-`),
   );
 
+  // Changing the PublishDir a temporary directory.
   // See https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid#recommended-action
   // about why we're not using `--output` for this.
-  args.push(`--property:PublishDir=${tempDir}`);
 
   // Some projects can have <IsPublishable> turned to false, that won't allow `publish` command to generate the binary we
   // need for resolution, so we're going to force <IsPublishable> to be true.
   // See https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-publish#msbuild
-  args.push('--p:IsPublishable=true');
+
+  // Some projects can have <PublishSingleFile> turned on, that won't generate the self-container binary we need,
+  // so we're disabling it during our scan.
+  // See https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/overview?tabs=cli
+  args.push(
+    `--p:PublishDir=${tempDir};IsPublishable=true;PublishSingleFile=false`,
+  );
 
   // The path that contains either some form of project file, or a .sln one.
   // See: https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-publish#arguments

--- a/test/fixtures/dotnetcore/dotnet_8_publish_single_file/dotnet_8_publish_single_file.csproj
+++ b/test/fixtures/dotnetcore/dotnet_8_publish_single_file/dotnet_8_publish_single_file.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <PublishSingleFile>true</PublishSingleFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" />
+  </ItemGroup>
+</Project>

--- a/test/fixtures/dotnetcore/dotnet_8_publish_single_file/expected_depgraph.json
+++ b/test/fixtures/dotnetcore/dotnet_8_publish_single_file/expected_depgraph.json
@@ -1,0 +1,757 @@
+{
+  "depGraph": {
+    "schemaVersion": "1.3.0",
+    "pkgManager": { "name": "nuget" },
+    "pkgs": [
+      {
+        "id": "dotnet_8_publish_single_file@1.0.0",
+        "info": {
+          "name": "dotnet_8_publish_single_file",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Data.SqlClient@5.2.1",
+        "info": {
+          "name": "Microsoft.Data.SqlClient",
+          "version": "5.2.1"
+        }
+      },
+      {
+        "id": "Azure.Identity@1.11.3",
+        "info": {
+          "name": "Azure.Identity",
+          "version": "1.11.3"
+        }
+      },
+      {
+        "id": "Azure.Core@1.38.0",
+        "info": {
+          "name": "Azure.Core",
+          "version": "1.38.0"
+        }
+      },
+      {
+        "id": "Microsoft.Bcl.AsyncInterfaces@1.1.1",
+        "info": {
+          "name": "Microsoft.Bcl.AsyncInterfaces",
+          "version": "1.1.1"
+        }
+      },
+      {
+        "id": "System.ClientModel@1.0.0",
+        "info": {
+          "name": "System.ClientModel",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "System.Memory.Data@1.0.2",
+        "info": {
+          "name": "System.Memory.Data",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "id": "System.Text.Encodings.Web@8.0.0",
+        "info": {
+          "name": "System.Text.Encodings.Web",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Text.Json@8.0.0",
+        "info": {
+          "name": "System.Text.Json",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Diagnostics.DiagnosticSource@8.0.0",
+        "info": {
+          "name": "System.Diagnostics.DiagnosticSource",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Runtime.CompilerServices.Unsafe@8.0.0",
+        "info": {
+          "name": "System.Runtime.CompilerServices.Unsafe",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Numerics.Vectors@8.0.0",
+        "info": {
+          "name": "System.Numerics.Vectors",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Threading.Tasks.Extensions@8.0.0",
+        "info": {
+          "name": "System.Threading.Tasks.Extensions",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Identity.Client@4.60.3",
+        "info": {
+          "name": "Microsoft.Identity.Client",
+          "version": "4.60.3"
+        }
+      },
+      {
+        "id": "Microsoft.IdentityModel.Abstractions@6.35.0",
+        "info": {
+          "name": "Microsoft.IdentityModel.Abstractions",
+          "version": "6.35.0"
+        }
+      },
+      {
+        "id": "Microsoft.Identity.Client.Extensions.Msal@4.60.3",
+        "info": {
+          "name": "Microsoft.Identity.Client.Extensions.Msal",
+          "version": "4.60.3"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.ProtectedData@8.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.ProtectedData",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Memory@8.0.0",
+        "info": {
+          "name": "System.Memory",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Data.SqlClient.SNI.runtime@5.2.0",
+        "info": {
+          "name": "Microsoft.Data.SqlClient.SNI.runtime",
+          "version": "5.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.IdentityModel.JsonWebTokens@6.35.0",
+        "info": {
+          "name": "Microsoft.IdentityModel.JsonWebTokens",
+          "version": "6.35.0"
+        }
+      },
+      {
+        "id": "Microsoft.IdentityModel.Tokens@6.35.0",
+        "info": {
+          "name": "Microsoft.IdentityModel.Tokens",
+          "version": "6.35.0"
+        }
+      },
+      {
+        "id": "Microsoft.CSharp@8.0.0",
+        "info": {
+          "name": "Microsoft.CSharp",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.IdentityModel.Logging@6.35.0",
+        "info": {
+          "name": "Microsoft.IdentityModel.Logging",
+          "version": "6.35.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.Cng@8.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.Cng",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Text.Encoding@8.0.0",
+        "info": {
+          "name": "System.Text.Encoding",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.NETCore.Platforms@1.1.0",
+        "info": {
+          "name": "Microsoft.NETCore.Platforms",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "id": "Microsoft.NETCore.Targets@1.1.0",
+        "info": {
+          "name": "Microsoft.NETCore.Targets",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "id": "System.Runtime@8.0.0",
+        "info": {
+          "name": "System.Runtime",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.IdentityModel.Protocols.OpenIdConnect@6.35.0",
+        "info": {
+          "name": "Microsoft.IdentityModel.Protocols.OpenIdConnect",
+          "version": "6.35.0"
+        }
+      },
+      {
+        "id": "Microsoft.IdentityModel.Protocols@6.35.0",
+        "info": {
+          "name": "Microsoft.IdentityModel.Protocols",
+          "version": "6.35.0"
+        }
+      },
+      {
+        "id": "System.IdentityModel.Tokens.Jwt@6.35.0",
+        "info": {
+          "name": "System.IdentityModel.Tokens.Jwt",
+          "version": "6.35.0"
+        }
+      },
+      {
+        "id": "Microsoft.SqlServer.Server@1.0.0",
+        "info": {
+          "name": "Microsoft.SqlServer.Server",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "System.Configuration.ConfigurationManager@8.0.0",
+        "info": {
+          "name": "System.Configuration.ConfigurationManager",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Diagnostics.EventLog@8.0.0",
+        "info": {
+          "name": "System.Diagnostics.EventLog",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Runtime.Caching@8.0.0",
+        "info": {
+          "name": "System.Runtime.Caching",
+          "version": "8.0.0"
+        }
+      }
+    ],
+    "graph": {
+      "rootNodeId": "root-node",
+      "nodes": [
+        {
+          "nodeId": "root-node",
+          "pkgId": "dotnet_8_publish_single_file@1.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Data.SqlClient@5.2.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Data.SqlClient@5.2.1",
+          "pkgId": "Microsoft.Data.SqlClient@5.2.1",
+          "deps": [
+            {
+              "nodeId": "Azure.Identity@1.11.3"
+            },
+            {
+              "nodeId": "Microsoft.Data.SqlClient.SNI.runtime@5.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Identity.Client@4.60.3:pruned"
+            },
+            {
+              "nodeId": "Microsoft.IdentityModel.JsonWebTokens@6.35.0"
+            },
+            {
+              "nodeId": "Microsoft.IdentityModel.Protocols.OpenIdConnect@6.35.0"
+            },
+            {
+              "nodeId": "Microsoft.SqlServer.Server@1.0.0"
+            },
+            {
+              "nodeId": "System.Configuration.ConfigurationManager@8.0.0"
+            },
+            {
+              "nodeId": "System.Runtime.Caching@8.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Azure.Identity@1.11.3",
+          "pkgId": "Azure.Identity@1.11.3",
+          "deps": [
+            {
+              "nodeId": "Azure.Core@1.38.0"
+            },
+            {
+              "nodeId": "Microsoft.Identity.Client@4.60.3"
+            },
+            {
+              "nodeId": "Microsoft.Identity.Client.Extensions.Msal@4.60.3"
+            },
+            {
+              "nodeId": "System.Memory@4.5.4"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.ProtectedData@8.0.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Json@4.7.2:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks.Extensions@4.5.4:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Azure.Core@1.38.0",
+          "pkgId": "Azure.Core@1.38.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Bcl.AsyncInterfaces@1.1.1"
+            },
+            {
+              "nodeId": "System.ClientModel@1.0.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.DiagnosticSource@6.0.1"
+            },
+            {
+              "nodeId": "System.Memory.Data@1.0.2:pruned"
+            },
+            {
+              "nodeId": "System.Numerics.Vectors@4.5.0"
+            },
+            {
+              "nodeId": "System.Text.Encodings.Web@4.7.2:pruned"
+            },
+            {
+              "nodeId": "System.Text.Json@4.7.2:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks.Extensions@4.5.4"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Bcl.AsyncInterfaces@1.1.1",
+          "pkgId": "Microsoft.Bcl.AsyncInterfaces@1.1.1",
+          "deps": []
+        },
+        {
+          "nodeId": "System.ClientModel@1.0.0",
+          "pkgId": "System.ClientModel@1.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Memory.Data@1.0.2"
+            },
+            {
+              "nodeId": "System.Text.Json@4.7.2:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Memory.Data@1.0.2",
+          "pkgId": "System.Memory.Data@1.0.2",
+          "deps": [
+            {
+              "nodeId": "System.Text.Encodings.Web@4.7.2"
+            },
+            {
+              "nodeId": "System.Text.Json@4.7.2"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Text.Encodings.Web@4.7.2",
+          "pkgId": "System.Text.Encodings.Web@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Text.Json@4.7.2",
+          "pkgId": "System.Text.Json@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Text.Json@4.7.2:pruned",
+          "pkgId": "System.Text.Json@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Diagnostics.DiagnosticSource@6.0.1",
+          "pkgId": "System.Diagnostics.DiagnosticSource@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Runtime.CompilerServices.Unsafe@6.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Runtime.CompilerServices.Unsafe@6.0.0",
+          "pkgId": "System.Runtime.CompilerServices.Unsafe@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Memory.Data@1.0.2:pruned",
+          "pkgId": "System.Memory.Data@1.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Numerics.Vectors@4.5.0",
+          "pkgId": "System.Numerics.Vectors@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Text.Encodings.Web@4.7.2:pruned",
+          "pkgId": "System.Text.Encodings.Web@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Threading.Tasks.Extensions@4.5.4",
+          "pkgId": "System.Threading.Tasks.Extensions@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Identity.Client@4.60.3",
+          "pkgId": "Microsoft.Identity.Client@4.60.3",
+          "deps": [
+            {
+              "nodeId": "Microsoft.IdentityModel.Abstractions@6.35.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.DiagnosticSource@6.0.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.IdentityModel.Abstractions@6.35.0",
+          "pkgId": "Microsoft.IdentityModel.Abstractions@6.35.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Diagnostics.DiagnosticSource@6.0.1:pruned",
+          "pkgId": "System.Diagnostics.DiagnosticSource@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Identity.Client.Extensions.Msal@4.60.3",
+          "pkgId": "Microsoft.Identity.Client.Extensions.Msal@4.60.3",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Identity.Client@4.60.3:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.ProtectedData@8.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Identity.Client@4.60.3:pruned",
+          "pkgId": "Microsoft.Identity.Client@4.60.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Security.Cryptography.ProtectedData@8.0.0",
+          "pkgId": "System.Security.Cryptography.ProtectedData@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Memory@4.5.4",
+          "pkgId": "System.Memory@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Security.Cryptography.ProtectedData@8.0.0:pruned",
+          "pkgId": "System.Security.Cryptography.ProtectedData@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Threading.Tasks.Extensions@4.5.4:pruned",
+          "pkgId": "System.Threading.Tasks.Extensions@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Data.SqlClient.SNI.runtime@5.2.0",
+          "pkgId": "Microsoft.Data.SqlClient.SNI.runtime@5.2.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.IdentityModel.JsonWebTokens@6.35.0",
+          "pkgId": "Microsoft.IdentityModel.JsonWebTokens@6.35.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.IdentityModel.Tokens@6.35.0"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.Encodings.Web@4.7.2:pruned"
+            },
+            {
+              "nodeId": "System.Text.Json@4.7.2:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.IdentityModel.Tokens@6.35.0",
+          "pkgId": "Microsoft.IdentityModel.Tokens@6.35.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.CSharp@4.5.0"
+            },
+            {
+              "nodeId": "Microsoft.IdentityModel.Logging@6.35.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Cng@4.5.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.CSharp@4.5.0",
+          "pkgId": "Microsoft.CSharp@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.IdentityModel.Logging@6.35.0",
+          "pkgId": "Microsoft.IdentityModel.Logging@6.35.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.IdentityModel.Abstractions@6.35.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.IdentityModel.Abstractions@6.35.0:pruned",
+          "pkgId": "Microsoft.IdentityModel.Abstractions@6.35.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Cng@4.5.0",
+          "pkgId": "System.Security.Cryptography.Cng@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Text.Encoding@4.3.0",
+          "pkgId": "System.Text.Encoding@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.NETCore.Platforms@1.1.0",
+          "pkgId": "Microsoft.NETCore.Platforms@1.1.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.NETCore.Targets@1.1.0",
+          "pkgId": "Microsoft.NETCore.Targets@1.1.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Runtime@4.3.0",
+          "pkgId": "System.Runtime@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.NETCore.Platforms@1.1.0:pruned",
+          "pkgId": "Microsoft.NETCore.Platforms@1.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned",
+          "pkgId": "Microsoft.NETCore.Targets@1.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.IdentityModel.Protocols.OpenIdConnect@6.35.0",
+          "pkgId": "Microsoft.IdentityModel.Protocols.OpenIdConnect@6.35.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.IdentityModel.Protocols@6.35.0"
+            },
+            {
+              "nodeId": "System.IdentityModel.Tokens.Jwt@6.35.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.IdentityModel.Protocols@6.35.0",
+          "pkgId": "Microsoft.IdentityModel.Protocols@6.35.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.IdentityModel.Logging@6.35.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.IdentityModel.Tokens@6.35.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.IdentityModel.Logging@6.35.0:pruned",
+          "pkgId": "Microsoft.IdentityModel.Logging@6.35.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.IdentityModel.Tokens@6.35.0:pruned",
+          "pkgId": "Microsoft.IdentityModel.Tokens@6.35.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.IdentityModel.Tokens.Jwt@6.35.0",
+          "pkgId": "System.IdentityModel.Tokens.Jwt@6.35.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.IdentityModel.JsonWebTokens@6.35.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.IdentityModel.Tokens@6.35.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.IdentityModel.JsonWebTokens@6.35.0:pruned",
+          "pkgId": "Microsoft.IdentityModel.JsonWebTokens@6.35.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.SqlServer.Server@1.0.0",
+          "pkgId": "Microsoft.SqlServer.Server@1.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Configuration.ConfigurationManager@8.0.0",
+          "pkgId": "System.Configuration.ConfigurationManager@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Diagnostics.EventLog@8.0.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.ProtectedData@8.0.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Diagnostics.EventLog@8.0.0",
+          "pkgId": "System.Diagnostics.EventLog@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Runtime.Caching@8.0.0",
+          "pkgId": "System.Runtime.Caching@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Configuration.ConfigurationManager@8.0.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Configuration.ConfigurationManager@8.0.0:pruned",
+          "pkgId": "System.Configuration.ConfigurationManager@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/dotnetcore/dotnet_8_publish_single_file/program.cs
+++ b/test/fixtures/dotnetcore/dotnet_8_publish_single_file/program.cs
@@ -1,0 +1,8 @@
+using System;
+class TestFixture {
+    static public void Main(String[] args)
+    {
+      var client = new System.Net.Http.HttpClient();
+      Console.WriteLine("Hello, World!");
+    }
+}

--- a/test/parsers/parse-core-v2.spec.ts
+++ b/test/parsers/parse-core-v2.spec.ts
@@ -107,6 +107,13 @@ describe('when generating depGraphs and runtime assemblies using the v2 parser',
       targetFramework: 'net8.0',
       manifestFilePath: 'obj/project.assets.json',
     },
+    {
+      description: 'parse dotnet 8.0 with PublishSingleFile turned on',
+      projectPath: './test/fixtures/dotnetcore/dotnet_8_publish_single_file',
+      projectFile: 'dotnet_8_publish_single_file.csproj',
+      targetFramework: 'net8.0',
+      manifestFilePath: 'obj/project.assets.json',
+    },
   ])(
     'succeeds given a project file and returns a single dependency graph for single-targetFramework projects: $description',
     async ({ projectPath, projectFile, manifestFilePath, targetFramework }) => {


### PR DESCRIPTION
Some projects can have `<PublishSingleFile>` tuned on, this won't allow `dotnet publish` to generate the self-container binary. This PR turns that setting to false during our scan