### PR TITLE
Include property to indicate Snyk is scanning

### DIFF
--- a/lib/nuget-parser/cli/dotnet.ts
+++ b/lib/nuget-parser/cli/dotnet.ts
@@ -111,7 +111,7 @@ export async function publish(
   // so we're disabling it during our scan.
   // See https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/overview?tabs=cli
   args.push(
-    `--p:PublishDir=${tempDir};IsPublishable=true;PublishSingleFile=false`,
+    `--p:PublishDir=${tempDir};SnykTest=true;IsPublishable=true;PublishSingleFile=false`,
   );
 
   // The path that contains either some form of project file, or a .sln one.


### PR DESCRIPTION
With a property for the publish process, we can detect this in our csproj files and use msbuild conditionals for targets or others that breaks or slows down Snyk scanning.

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
This will add a property that can be used to detect that the build process is initiated by a Snyk test. This can be helpful in cases there are targets in the csproj files that should not run during this process because it would break, or because it is time consuming.

The name of the property is absolutely up for discussion as this is more to initiate the discussion on the property itself

#### Where should the reviewer start?


#### How should this be manually tested?
Add a conditional on a target or property in a csproj that is not running when the property is set to true: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-conditions?view=vs-2022

#### Any background context you want to provide?
We are seeing this issue with the .NET improved scanning running in the Snyk infrastructure where some pieces are missing there and that prevents us from importing some projects. So we would like both the Snyk CLI and the SCM native integration to both provide a property we can use to detect when Snyk is running and avoid those targets that breaks the build (as they are not relevant to find the dependencies).

#### What are the relevant tickets?
https://support.snyk.io/hc/en-us/requests/91175

#### Screenshots


#### Additional questions
