### PR TITLE
fix:do not treat warnings as errors

### DIFF
--- a/lib/nuget-parser/cli/dotnet.ts
+++ b/lib/nuget-parser/cli/dotnet.ts
@@ -110,8 +110,11 @@ export async function publish(
   // Some projects can have <PublishSingleFile> turned on, that won't generate the self-container binary we need,
   // so we're disabling it during our scan.
   // See https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/overview?tabs=cli
+
+  // Some projects can have <TreatWarningsAsErrors> tuned on, that will throw errors on any warning, making the project impossible to scan.
+  // Or, they can have a list of warning codes in <WarningsAsErrors> that will do the same thing as above. So we're disabling them.
   args.push(
-    `--p:PublishDir=${tempDir};IsPublishable=true;PublishSingleFile=false`,
+    `--p:PublishDir=${tempDir};IsPublishable=true;PublishSingleFile=false;TreatWarningsAsErrors=false;WarningsAsErrors=`,
   );
 
   // The path that contains either some form of project file, or a .sln one.

--- a/test/fixtures/dotnetcore/dotnet_8_treat_warnings_as_errors/dotnet_8_treat_warnings_as_errors.csproj
+++ b/test/fixtures/dotnetcore/dotnet_8_treat_warnings_as_errors/dotnet_8_treat_warnings_as_errors.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors>CS0618</WarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Vulnerable dependency -->
+    <PackageVersion Include="System.Text.Json" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/test/fixtures/dotnetcore/dotnet_8_treat_warnings_as_errors/expected_depgraph.json
+++ b/test/fixtures/dotnetcore/dotnet_8_treat_warnings_as_errors/expected_depgraph.json
@@ -1,0 +1,27 @@
+{
+  "depGraph": {
+    "schemaVersion": "1.3.0",
+    "pkgManager": {
+      "name": "nuget"
+    },
+    "pkgs": [
+      {
+        "id": "dotnet_8_treat_warnings_as_errors@1.0.0",
+        "info": {
+          "name": "dotnet_8_treat_warnings_as_errors",
+          "version": "1.0.0"
+        }
+      }
+    ],
+    "graph": {
+      "rootNodeId": "root-node",
+      "nodes": [
+        {
+          "nodeId": "root-node",
+          "pkgId": "dotnet_8_treat_warnings_as_errors@1.0.0",
+          "deps": []
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/dotnetcore/dotnet_8_treat_warnings_as_errors/program.cs
+++ b/test/fixtures/dotnetcore/dotnet_8_treat_warnings_as_errors/program.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace WarningAsErrorExample
+{
+    class Program
+    {
+        [Obsolete("This method is deprecated.")]
+        static void ObsoleteMethod()
+        {
+            Console.WriteLine("This method is obsolete.");
+        }
+
+        static void Main(string[] args)
+        {
+            // This will trigger warning CS0618
+            ObsoleteMethod();
+        }
+    }
+}

--- a/test/parsers/parse-core-v2.spec.ts
+++ b/test/parsers/parse-core-v2.spec.ts
@@ -114,6 +114,15 @@ describe('when generating depGraphs and runtime assemblies using the v2 parser',
       targetFramework: 'net8.0',
       manifestFilePath: 'obj/project.assets.json',
     },
+    {
+      description:
+        'parse dotnet 8.0 with TreatWarningsAsErrors and WarningsAsErrors',
+      projectPath:
+        './test/fixtures/dotnetcore/dotnet_8_treat_warnings_as_errors',
+      projectFile: 'dotnet_8_treat_warnings_as_errors.csproj',
+      targetFramework: 'net8.0',
+      manifestFilePath: 'obj/project.assets.json',
+    },
   ])(
     'succeeds given a project file and returns a single dependency graph for single-targetFramework projects: $description',
     async ({ projectPath, projectFile, manifestFilePath, targetFramework }) => {


### PR DESCRIPTION
Projects can have properties like `<TreatWarningsAsErrors>` and `<WarningsAsErrors>` that will make the `dotnet publish` command to fail for any encountered warning. There is no reason for us to fail the scan if dotnet detected a warning. In lots of cases those warnings are from the range: https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1901-nu1904

This PR deactivated those two settings when running `dotnet publish`