### PR TITLE
fix: do not treat warnings as errors on restore

### DIFF
--- a/lib/nuget-parser/cli/dotnet.ts
+++ b/lib/nuget-parser/cli/dotnet.ts
@@ -59,6 +59,7 @@ export async function restore(projectPath: string): Promise<void> {
     '--verbosity',
     'normal',
     `"${projectPath}"`,
+    '--p=TreatWarningsAsErrors=false;WarningsAsErrors=',
   ];
   await handle('restore', command, args);
   return;


### PR DESCRIPTION
Same as https://github.com/snyk/snyk-nuget-plugin/pull/223 but for `dotnet restore`