### PR TITLE
fix: default to filename as proj name for target

### DIFF
--- a/test/fixtures/dotnetcore/dotnet_8_with_package_id_property/dotnet_8_with_package_id_property.csproj
+++ b/test/fixtures/dotnetcore/dotnet_8_with_package_id_property/dotnet_8_with_package_id_property.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Company>Snyk</Company>
+    <PackageId>Snyk.Project.Name</PackageId>
+    <Authors>Snyk</Authors>
+    <Description>This is a description</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.13.3" />
+  </ItemGroup>
+</Project>

--- a/test/fixtures/dotnetcore/dotnet_8_with_package_id_property/expected_depgraph.json
+++ b/test/fixtures/dotnetcore/dotnet_8_with_package_id_property/expected_depgraph.json
@@ -1,0 +1,75 @@
+{
+  "depGraph": {
+    "schemaVersion": "1.3.0",
+    "pkgManager": {
+      "name": "nuget"
+    },
+    "pkgs": [
+      {
+        "id": "dotnet_8_with_package_id_property@1.0.0",
+        "info": {
+          "name": "dotnet_8_with_package_id_property",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "NUnit@3.13.3",
+        "info": {
+          "name": "NUnit",
+          "version": "3.13.3"
+        }
+      },
+      {
+        "id": "NETStandard.Library@2.0.0",
+        "info": {
+          "name": "NETStandard.Library",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.NETCore.Platforms@1.1.0",
+        "info": {
+          "name": "Microsoft.NETCore.Platforms",
+          "version": "1.1.0"
+        }
+      }
+    ],
+    "graph": {
+      "rootNodeId": "root-node",
+      "nodes": [
+        {
+          "nodeId": "root-node",
+          "pkgId": "dotnet_8_with_package_id_property@1.0.0",
+          "deps": [
+            {
+              "nodeId": "NUnit@3.13.3"
+            }
+          ]
+        },
+        {
+          "nodeId": "NUnit@3.13.3",
+          "pkgId": "NUnit@3.13.3",
+          "deps": [
+            {
+              "nodeId": "NETStandard.Library@2.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "NETStandard.Library@2.0.0",
+          "pkgId": "NETStandard.Library@2.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.NETCore.Platforms@1.1.0",
+          "pkgId": "Microsoft.NETCore.Platforms@1.1.0",
+          "deps": []
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/dotnetcore/dotnet_8_with_package_id_property/program.cs
+++ b/test/fixtures/dotnetcore/dotnet_8_with_package_id_property/program.cs
@@ -1,0 +1,8 @@
+﻿using System;
+class TestFixture {
+    static public void Main(String[] args)
+    {
+      var client = new System.Net.Http.HttpClient();
+      Console.WriteLine("Hello, World!");
+    }
+}

--- a/test/parsers/parse-core-v2.spec.ts
+++ b/test/parsers/parse-core-v2.spec.ts
@@ -131,6 +131,14 @@ describe('when generating depGraphs and runtime assemblies using the v2 parser',
       targetFramework: 'net8.0',
       manifestFilePath: 'obj/project.assets.json',
     },
+    {
+      description: 'parse dotnet 8.0 with PackageId property',
+      projectPath:
+        './test/fixtures/dotnetcore/dotnet_8_with_package_id_property',
+      projectFile: 'dotnet_8_with_package_id_property.csproj',
+      targetFramework: 'net8.0',
+      manifestFilePath: 'obj/project.assets.json',
+    },
   ])(
     'succeeds given a project file and returns a single dependency graph for single-targetFramework projects: $description',
     async ({ projectPath, projectFile, manifestFilePath, targetFramework }) => {
@@ -159,6 +167,7 @@ describe('when generating depGraphs and runtime assemblies using the v2 parser',
         expectedGraph.depGraph,
       );
     },
+    1000000,
   );
 
   it.each([


### PR DESCRIPTION
Dotnet is not consistent with project names, this PR adds a default to find the target using the .csproj filename.
<PackageId> property overrides most of the naming when restoring, but when publishing, the self-contained binary will have the actual filename as the target.