### PR TITLE
fix: adds dotnet 9 to smoke tests and removes progress indicators

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ matrix_windows_node_version: &matrix_windows_node_version
   node_version: [ "16.20.0", "18.16.0", "20.3.1" ]
 
 matrix_dotnet_version: &matrix_dotnet_version
-  dotnet_version: [ "8.0", "7.0", "6.0" ]
+  dotnet_version: [ "9.0", "8.0", "7.0", "6.0" ]
 
 filters_branches_only_main: &filters_branches_only_main
   filters:
@@ -238,7 +238,7 @@ workflows:
             parameters:
               <<: *matrix_unix_node_version
               test_type: [ "unit" ]
-              dotnet_version: [ "8.0" ]
+              dotnet_version: [ "9.0" ]
           name: Unix Unit Tests for Node=<< matrix.node_version >>
           context: nodejs-install
           node_version: "<< matrix.node_version >>"
@@ -266,7 +266,7 @@ workflows:
             parameters:
               <<: *matrix_windows_node_version
               test_type: [ "unit" ]
-              dotnet_version: [ "8.0" ]
+              dotnet_version: [ "9.0" ]
           name: Windows Unit Tests for Node=<< matrix.node_version >>
           context: nodejs-install
           node_version: "<< matrix.node_version >>"

--- a/lib/nuget-parser/cli/dotnet.ts
+++ b/lib/nuget-parser/cli/dotnet.ts
@@ -72,7 +72,10 @@ export async function run(
   const command = 'dotnet';
   const args = ['run', '--project', projectPath].concat(options);
   const response = await handle('run', command, args);
-  return response.stdout;
+  const stdout = response.stdout;
+  return stdout.slice(
+    stdout.indexOf('{') !== -1 ? stdout.indexOf('{') : stdout.length,
+  );
 }
 
 export async function publish(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "./dist",
     "pretty": true,
-    "target": "es2019",
+    "target": "es2021",
     "module": "commonjs",
     "sourceMap": true,
     "declaration": true,


### PR DESCRIPTION
adds version 9 to the smoke tests
and a workaround until https://github.com/dotnet/sdk/issues/44610 gets fixed, hopefully on the next dotnet sdk release