### PR TITLE
fix: false positives from transitive deps

### DIFF
--- a/test/fixtures/dotnetcore/dotnet_8_transitive_false_positive/FirstProject/dotnet_8_transitive_false_positive.csproj
+++ b/test/fixtures/dotnetcore/dotnet_8_transitive_false_positive/FirstProject/dotnet_8_transitive_false_positive.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.RabbitMQ.Client" Version="8.2.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference
+      Include="..\SecondProject\dotnet_8_second_project.csproj"
+    />
+  </ItemGroup>
+</Project>

--- a/test/fixtures/dotnetcore/dotnet_8_transitive_false_positive/FirstProject/expected_depgraph.json
+++ b/test/fixtures/dotnetcore/dotnet_8_transitive_false_positive/FirstProject/expected_depgraph.json
@@ -1,0 +1,767 @@
+{
+  "depGraph": {
+    "schemaVersion": "1.3.0",
+    "pkgManager": {
+      "name": "nuget"
+    },
+    "pkgs": [
+      {
+        "id": "FirstProject@1.0.0",
+        "info": {
+          "name": "FirstProject",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "Aspire.RabbitMQ.Client@8.2.2",
+        "info": {
+          "name": "Aspire.RabbitMQ.Client",
+          "version": "8.2.2"
+        }
+      },
+      {
+        "id": "AspNetCore.HealthChecks.Rabbitmq@8.0.2",
+        "info": {
+          "name": "AspNetCore.HealthChecks.Rabbitmq",
+          "version": "8.0.2"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Diagnostics.HealthChecks@8.0.10",
+        "info": {
+          "name": "Microsoft.Extensions.Diagnostics.HealthChecks",
+          "version": "8.0.10"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions@8.0.10",
+        "info": {
+          "name": "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions",
+          "version": "8.0.10"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Hosting.Abstractions@8.0.1",
+        "info": {
+          "name": "Microsoft.Extensions.Hosting.Abstractions",
+          "version": "8.0.1"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
+        "info": {
+          "name": "Microsoft.Extensions.Configuration.Abstractions",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Primitives@8.0.0",
+        "info": {
+          "name": "Microsoft.Extensions.Primitives",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2",
+        "info": {
+          "name": "Microsoft.Extensions.DependencyInjection.Abstractions",
+          "version": "8.0.2"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Diagnostics.Abstractions@8.0.1",
+        "info": {
+          "name": "Microsoft.Extensions.Diagnostics.Abstractions",
+          "version": "8.0.1"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Options@8.0.2",
+        "info": {
+          "name": "Microsoft.Extensions.Options",
+          "version": "8.0.2"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.FileProviders.Abstractions@8.0.0",
+        "info": {
+          "name": "Microsoft.Extensions.FileProviders.Abstractions",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Logging.Abstractions@8.0.2",
+        "info": {
+          "name": "Microsoft.Extensions.Logging.Abstractions",
+          "version": "8.0.2"
+        }
+      },
+      {
+        "id": "RabbitMQ.Client@6.8.1",
+        "info": {
+          "name": "RabbitMQ.Client",
+          "version": "6.8.1"
+        }
+      },
+      {
+        "id": "System.Memory@8.0.0",
+        "info": {
+          "name": "System.Memory",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Threading.Channels@8.0.0",
+        "info": {
+          "name": "System.Threading.Channels",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Configuration.Binder@8.0.2",
+        "info": {
+          "name": "Microsoft.Extensions.Configuration.Binder",
+          "version": "8.0.2"
+        }
+      },
+      {
+        "id": "OpenTelemetry.Extensions.Hosting@1.9.0",
+        "info": {
+          "name": "OpenTelemetry.Extensions.Hosting",
+          "version": "1.9.0"
+        }
+      },
+      {
+        "id": "OpenTelemetry@1.9.0",
+        "info": {
+          "name": "OpenTelemetry",
+          "version": "1.9.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Logging.Configuration@8.0.0",
+        "info": {
+          "name": "Microsoft.Extensions.Logging.Configuration",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Configuration@8.0.0",
+        "info": {
+          "name": "Microsoft.Extensions.Configuration",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Logging@8.0.1",
+        "info": {
+          "name": "Microsoft.Extensions.Logging",
+          "version": "8.0.1"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.DependencyInjection@8.0.1",
+        "info": {
+          "name": "Microsoft.Extensions.DependencyInjection",
+          "version": "8.0.1"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Options.ConfigurationExtensions@8.0.0",
+        "info": {
+          "name": "Microsoft.Extensions.Options.ConfigurationExtensions",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "OpenTelemetry.Api.ProviderBuilderExtensions@1.9.0",
+        "info": {
+          "name": "OpenTelemetry.Api.ProviderBuilderExtensions",
+          "version": "1.9.0"
+        }
+      },
+      {
+        "id": "OpenTelemetry.Api@1.9.0",
+        "info": {
+          "name": "OpenTelemetry.Api",
+          "version": "1.9.0"
+        }
+      },
+      {
+        "id": "System.Diagnostics.DiagnosticSource@8.0.0",
+        "info": {
+          "name": "System.Diagnostics.DiagnosticSource",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Polly.Core@8.4.2",
+        "info": {
+          "name": "Polly.Core",
+          "version": "8.4.2"
+        }
+      },
+      {
+        "id": "dotnet_8_second_project@1.0.0",
+        "info": {
+          "name": "dotnet_8_second_project",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.EntityFrameworkCore@8.0.12",
+        "info": {
+          "name": "Microsoft.EntityFrameworkCore",
+          "version": "8.0.12"
+        }
+      },
+      {
+        "id": "Microsoft.EntityFrameworkCore.Abstractions@8.0.12",
+        "info": {
+          "name": "Microsoft.EntityFrameworkCore.Abstractions",
+          "version": "8.0.12"
+        }
+      },
+      {
+        "id": "Microsoft.EntityFrameworkCore.Analyzers@8.0.12",
+        "info": {
+          "name": "Microsoft.EntityFrameworkCore.Analyzers",
+          "version": "8.0.12"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Caching.Memory@8.0.1",
+        "info": {
+          "name": "Microsoft.Extensions.Caching.Memory",
+          "version": "8.0.1"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Caching.Abstractions@8.0.0",
+        "info": {
+          "name": "Microsoft.Extensions.Caching.Abstractions",
+          "version": "8.0.0"
+        }
+      }
+    ],
+    "graph": {
+      "rootNodeId": "root-node",
+      "nodes": [
+        {
+          "nodeId": "root-node",
+          "pkgId": "FirstProject@1.0.0",
+          "deps": [
+            {
+              "nodeId": "Aspire.RabbitMQ.Client@8.2.2"
+            },
+            {
+              "nodeId": "dotnet_8_second_project@1.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Aspire.RabbitMQ.Client@8.2.2",
+          "pkgId": "Aspire.RabbitMQ.Client@8.2.2",
+          "deps": [
+            {
+              "nodeId": "AspNetCore.HealthChecks.Rabbitmq@8.0.2"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Binder@8.0.2"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Diagnostics.HealthChecks@8.0.10:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Hosting.Abstractions@8.0.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@8.0.0:pruned"
+            },
+            {
+              "nodeId": "OpenTelemetry.Extensions.Hosting@1.9.0"
+            },
+            {
+              "nodeId": "Polly.Core@8.4.2"
+            },
+            {
+              "nodeId": "RabbitMQ.Client@6.8.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "AspNetCore.HealthChecks.Rabbitmq@8.0.2",
+          "pkgId": "AspNetCore.HealthChecks.Rabbitmq@8.0.2",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Diagnostics.HealthChecks@8.0.10"
+            },
+            {
+              "nodeId": "RabbitMQ.Client@6.8.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Diagnostics.HealthChecks@8.0.10",
+          "pkgId": "Microsoft.Extensions.Diagnostics.HealthChecks@8.0.10",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions@8.0.10"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Hosting.Abstractions@8.0.1"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions@8.0.10",
+          "pkgId": "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions@8.0.10",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Hosting.Abstractions@8.0.1",
+          "pkgId": "Microsoft.Extensions.Hosting.Abstractions@8.0.1",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Diagnostics.Abstractions@8.0.1"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.FileProviders.Abstractions@8.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
+          "pkgId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@8.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Primitives@8.0.0",
+          "pkgId": "Microsoft.Extensions.Primitives@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2",
+          "pkgId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Diagnostics.Abstractions@8.0.1",
+          "pkgId": "Microsoft.Extensions.Diagnostics.Abstractions@8.0.1",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned",
+          "pkgId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Options@8.0.2",
+          "pkgId": "Microsoft.Extensions.Options@8.0.2",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@8.0.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Primitives@8.0.0:pruned",
+          "pkgId": "Microsoft.Extensions.Primitives@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.FileProviders.Abstractions@8.0.0",
+          "pkgId": "Microsoft.Extensions.FileProviders.Abstractions@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@8.0.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2",
+          "pkgId": "Microsoft.Extensions.Logging.Abstractions@8.0.2",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2:pruned",
+          "pkgId": "Microsoft.Extensions.Logging.Abstractions@8.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Options@8.0.2:pruned",
+          "pkgId": "Microsoft.Extensions.Options@8.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "RabbitMQ.Client@6.8.1",
+          "pkgId": "RabbitMQ.Client@6.8.1",
+          "deps": [
+            {
+              "nodeId": "System.Memory@4.5.5"
+            },
+            {
+              "nodeId": "System.Threading.Channels@7.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Memory@4.5.5",
+          "pkgId": "System.Memory@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Threading.Channels@7.0.0",
+          "pkgId": "System.Threading.Channels@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned",
+          "pkgId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.Binder@8.0.2",
+          "pkgId": "Microsoft.Extensions.Configuration.Binder@8.0.2",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Diagnostics.HealthChecks@8.0.10:pruned",
+          "pkgId": "Microsoft.Extensions.Diagnostics.HealthChecks@8.0.10",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Hosting.Abstractions@8.0.1:pruned",
+          "pkgId": "Microsoft.Extensions.Hosting.Abstractions@8.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "OpenTelemetry.Extensions.Hosting@1.9.0",
+          "pkgId": "OpenTelemetry.Extensions.Hosting@1.9.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Hosting.Abstractions@8.0.1:pruned"
+            },
+            {
+              "nodeId": "OpenTelemetry@1.9.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "OpenTelemetry@1.9.0",
+          "pkgId": "OpenTelemetry@1.9.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Diagnostics.Abstractions@8.0.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Configuration@8.0.0"
+            },
+            {
+              "nodeId": "OpenTelemetry.Api.ProviderBuilderExtensions@1.9.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Diagnostics.Abstractions@8.0.1:pruned",
+          "pkgId": "Microsoft.Extensions.Diagnostics.Abstractions@8.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Logging.Configuration@8.0.0",
+          "pkgId": "Microsoft.Extensions.Logging.Configuration@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration@8.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Binder@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging@8.0.1"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options.ConfigurationExtensions@8.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration@8.0.0",
+          "pkgId": "Microsoft.Extensions.Configuration@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@8.0.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.Binder@8.0.2:pruned",
+          "pkgId": "Microsoft.Extensions.Configuration.Binder@8.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Logging@8.0.1",
+          "pkgId": "Microsoft.Extensions.Logging@8.0.1",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection@8.0.1"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.DependencyInjection@8.0.1",
+          "pkgId": "Microsoft.Extensions.DependencyInjection@8.0.1",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Options.ConfigurationExtensions@8.0.0",
+          "pkgId": "Microsoft.Extensions.Options.ConfigurationExtensions@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Binder@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@8.0.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "OpenTelemetry.Api.ProviderBuilderExtensions@1.9.0",
+          "pkgId": "OpenTelemetry.Api.ProviderBuilderExtensions@1.9.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "OpenTelemetry.Api@1.9.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "OpenTelemetry.Api@1.9.0",
+          "pkgId": "OpenTelemetry.Api@1.9.0",
+          "deps": [
+            {
+              "nodeId": "System.Diagnostics.DiagnosticSource@8.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Diagnostics.DiagnosticSource@8.0.0",
+          "pkgId": "System.Diagnostics.DiagnosticSource@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Polly.Core@8.4.2",
+          "pkgId": "Polly.Core@8.4.2",
+          "deps": []
+        },
+        {
+          "nodeId": "RabbitMQ.Client@6.8.1:pruned",
+          "pkgId": "RabbitMQ.Client@6.8.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "dotnet_8_second_project@1.0.0",
+          "pkgId": "dotnet_8_second_project@1.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.EntityFrameworkCore@8.0.12"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.EntityFrameworkCore@8.0.12",
+          "pkgId": "Microsoft.EntityFrameworkCore@8.0.12",
+          "deps": [
+            {
+              "nodeId": "Microsoft.EntityFrameworkCore.Abstractions@8.0.12"
+            },
+            {
+              "nodeId": "Microsoft.EntityFrameworkCore.Analyzers@8.0.12"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Caching.Memory@8.0.1"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging@8.0.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.EntityFrameworkCore.Abstractions@8.0.12",
+          "pkgId": "Microsoft.EntityFrameworkCore.Abstractions@8.0.12",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.EntityFrameworkCore.Analyzers@8.0.12",
+          "pkgId": "Microsoft.EntityFrameworkCore.Analyzers@8.0.12",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Caching.Memory@8.0.1",
+          "pkgId": "Microsoft.Extensions.Caching.Memory@8.0.1",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Caching.Abstractions@8.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@8.0.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Caching.Abstractions@8.0.0",
+          "pkgId": "Microsoft.Extensions.Caching.Abstractions@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@8.0.0"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/dotnetcore/dotnet_8_transitive_false_positive/FirstProject/program.cs
+++ b/test/fixtures/dotnetcore/dotnet_8_transitive_false_positive/FirstProject/program.cs
@@ -1,0 +1,8 @@
+using System;
+class TestFixture {
+    static public void Main(String[] args)
+    {
+      var client = new System.Net.Http.HttpClient();
+      Console.WriteLine("Hello, World!");
+    }
+}

--- a/test/fixtures/dotnetcore/dotnet_8_transitive_false_positive/SecondProject/dotnet_8_second_project.csproj
+++ b/test/fixtures/dotnetcore/dotnet_8_transitive_false_positive/SecondProject/dotnet_8_second_project.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference
+      Include="Microsoft.EntityFrameworkCore"
+      Version="8.0.12"
+    />
+  </ItemGroup>
+</Project>

--- a/test/fixtures/dotnetcore/dotnet_8_transitive_false_positive/SecondProject/program.cs
+++ b/test/fixtures/dotnetcore/dotnet_8_transitive_false_positive/SecondProject/program.cs
@@ -1,0 +1,8 @@
+using System;
+class TestFixture {
+    static public void Main(String[] args)
+    {
+      var client = new System.Net.Http.HttpClient();
+      Console.WriteLine("Hello, World!");
+    }
+}

--- a/test/parsers/parse-core-v2.spec.ts
+++ b/test/parsers/parse-core-v2.spec.ts
@@ -147,6 +147,14 @@ describe('when generating depGraphs and runtime assemblies using the v2 parser',
       targetFramework: 'net8.0',
       manifestFilePath: 'obj/project.assets.json',
     },
+    {
+      description: 'parse dotnet 8.0 transitive false positive',
+      projectPath:
+        './test/fixtures/dotnetcore/dotnet_8_transitive_false_positive/FirstProject',
+      projectFile: 'dotnet_8_transitive_false_positive.csproj',
+      targetFramework: 'net8.0',
+      manifestFilePath: 'obj/project.assets.json',
+    },
   ])(
     'succeeds given a project file and returns a single dependency graph for single-targetFramework projects: $description',
     async ({ projectPath, projectFile, manifestFilePath, targetFramework }) => {


### PR DESCRIPTION
Imported projects (from NuGet/private NuGet Feeds) can also influence the version of the runtime dependency. 
The correct NuGet version is hoisted from the inner projects to the main self-container binary as an empty object.
This PR will take them into account. 