### PR TITLE
fix: disable error on duplicate output files

### DIFF
--- a/lib/nuget-parser/cli/dotnet.ts
+++ b/lib/nuget-parser/cli/dotnet.ts
@@ -117,8 +117,11 @@ export async function publish(
 
   // Some projects can have <TreatWarningsAsErrors> tuned on, that will throw errors on any warning, making the project impossible to scan.
   // Or, they can have a list of warning codes in <WarningsAsErrors> that will do the same thing as above. So we're disabling them.
+
+  // Some projects may include duplicate files in the publish output due to shared dependencies or multi-targeting,
+  // causing build failures. We're disabling <ErrorOnDuplicatePublishOutputFiles> to allow publish to proceed without errors.
   args.push(
-    `--p:PublishDir=${tempDir};SnykTest=true;IsPublishable=true;PublishSingleFile=false;TreatWarningsAsErrors=false;WarningsAsErrors=`,
+    `--p:PublishDir=${tempDir};SnykTest=true;IsPublishable=true;PublishSingleFile=false;TreatWarningsAsErrors=false;ErrorOnDuplicatePublishOutputFiles=false;WarningsAsErrors=`,
   );
 
   // The path that contains either some form of project file, or a .sln one.

--- a/test/fixtures/dotnetcore/dotnet_8_duplicate_publish_output_files/FirstProject/appsettings.json
+++ b/test/fixtures/dotnetcore/dotnet_8_duplicate_publish_output_files/FirstProject/appsettings.json
@@ -1,0 +1,13 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "System": "Error"
+    }
+  },
+  "AppSettings": {
+    "Setting1": "Value1",
+    "Setting2": "Value2"
+  }
+}

--- a/test/fixtures/dotnetcore/dotnet_8_duplicate_publish_output_files/FirstProject/dotnet_8_duplicate_publish_output.csproj
+++ b/test/fixtures/dotnetcore/dotnet_8_duplicate_publish_output_files/FirstProject/dotnet_8_duplicate_publish_output.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference
+      Include="..\SecondProject\dotnet_8_duplicate_publish_output_second.csproj"
+    />
+  </ItemGroup>
+</Project>

--- a/test/fixtures/dotnetcore/dotnet_8_duplicate_publish_output_files/FirstProject/expected_depgraph.json
+++ b/test/fixtures/dotnetcore/dotnet_8_duplicate_publish_output_files/FirstProject/expected_depgraph.json
@@ -1,0 +1,43 @@
+{
+  "depGraph": {
+    "schemaVersion": "1.3.0",
+    "pkgManager": {
+      "name": "nuget"
+    },
+    "pkgs": [
+      {
+        "id": "FirstProject@1.0.0",
+        "info": {
+          "name": "FirstProject",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "dotnet_8_duplicate_publish_output_second@1.0.0",
+        "info": {
+          "name": "dotnet_8_duplicate_publish_output_second",
+          "version": "1.0.0"
+        }
+      }
+    ],
+    "graph": {
+      "rootNodeId": "root-node",
+      "nodes": [
+        {
+          "nodeId": "root-node",
+          "pkgId": "FirstProject@1.0.0",
+          "deps": [
+            {
+              "nodeId": "dotnet_8_duplicate_publish_output_second@1.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "dotnet_8_duplicate_publish_output_second@1.0.0",
+          "pkgId": "dotnet_8_duplicate_publish_output_second@1.0.0",
+          "deps": []
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/dotnetcore/dotnet_8_duplicate_publish_output_files/SecondProject/appsettings.json
+++ b/test/fixtures/dotnetcore/dotnet_8_duplicate_publish_output_files/SecondProject/appsettings.json
@@ -1,0 +1,13 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "System": "Error"
+    }
+  },
+  "AppSettings": {
+    "Setting1": "Value1",
+    "Setting2": "Value2"
+  }
+}

--- a/test/fixtures/dotnetcore/dotnet_8_duplicate_publish_output_files/SecondProject/dotnet_8_duplicate_publish_output_second.csproj
+++ b/test/fixtures/dotnetcore/dotnet_8_duplicate_publish_output_files/SecondProject/dotnet_8_duplicate_publish_output_second.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/test/parsers/parse-core-v2.spec.ts
+++ b/test/parsers/parse-core-v2.spec.ts
@@ -155,6 +155,15 @@ describe('when generating depGraphs and runtime assemblies using the v2 parser',
       targetFramework: 'net8.0',
       manifestFilePath: 'obj/project.assets.json',
     },
+    {
+      description:
+        'parse dotnet 8.0 multiple publish output files with the same relative path',
+      projectPath:
+        './test/fixtures/dotnetcore/dotnet_8_duplicate_publish_output_files/FirstProject',
+      projectFile: 'dotnet_8_duplicate_publish_output.csproj',
+      targetFramework: 'net8.0',
+      manifestFilePath: 'obj/project.assets.json',
+    },
   ])(
     'succeeds given a project file and returns a single dependency graph for single-targetFramework projects: $description',
     async ({ projectPath, projectFile, manifestFilePath, targetFramework }) => {


### PR DESCRIPTION
some projects can be configured to always output files like appsettings.json to the output directory, and that is not a problem for normal publish actions, but we are publishing to a temp directory which will result in a NETSDK1152 error
disabling that error as those files are not relevant to the deps discovery