### PR TITLE
fix: set MSBuildEnableWorkloadResolver so we can always run the restore command

### DIFF
--- a/lib/nuget-parser/cli/dotnet.ts
+++ b/lib/nuget-parser/cli/dotnet.ts
@@ -80,7 +80,7 @@ export async function restore(
     '--verbosity',
     'normal',
     `"${projectPath}"`,
-    '--p=TreatWarningsAsErrors=false;WarningsAsErrors=',
+    '--p=MSBuildEnableWorkloadResolver=true;TreatWarningsAsErrors=false;WarningsAsErrors=',
   ];
   await handle('restore', command, args, workingDirectory);
   return;


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
set MSBuildEnableWorkloadResolver to true when running the restore command. This is to ensure the command works even when the setting is off when set in the csproj or prop files.

