### PR TITLE
fix: discover pinned dependencies

### DIFF
--- a/test/fixtures/dotnetcore/dotnet-8-windows-targeting/expected_depgraph-v3.json
+++ b/test/fixtures/dotnetcore/dotnet-8-windows-targeting/expected_depgraph-v3.json
@@ -27,55 +27,6 @@
         }
       },
       {
-        "id": "RabbitMQ.Client@6.8.1",
-        "info": {
-          "name": "RabbitMQ.Client",
-          "version": "6.8.1"
-        }
-      },
-      {
-        "id": "System.Memory@8.0.0",
-        "info": {
-          "name": "System.Memory",
-          "version": "8.0.0"
-        }
-      },
-      {
-        "id": "System.Threading.Channels@7.0.0",
-        "info": {
-          "name": "System.Threading.Channels",
-          "version": "7.0.0"
-        }
-      },
-      {
-        "id": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
-        "info": {
-          "name": "Microsoft.Extensions.Configuration.Abstractions",
-          "version": "8.0.0"
-        }
-      },
-      {
-        "id": "Microsoft.Extensions.Primitives@8.0.0",
-        "info": {
-          "name": "Microsoft.Extensions.Primitives",
-          "version": "8.0.0"
-        }
-      },
-      {
-        "id": "Microsoft.Extensions.Configuration.Binder@8.0.2",
-        "info": {
-          "name": "Microsoft.Extensions.Configuration.Binder",
-          "version": "8.0.2"
-        }
-      },
-      {
-        "id": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2",
-        "info": {
-          "name": "Microsoft.Extensions.DependencyInjection.Abstractions",
-          "version": "8.0.2"
-        }
-      },
-      {
         "id": "Microsoft.Extensions.Diagnostics.HealthChecks@8.0.10",
         "info": {
           "name": "Microsoft.Extensions.Diagnostics.HealthChecks",
@@ -94,6 +45,27 @@
         "info": {
           "name": "Microsoft.Extensions.Hosting.Abstractions",
           "version": "8.0.1"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
+        "info": {
+          "name": "Microsoft.Extensions.Configuration.Abstractions",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Primitives@8.0.0",
+        "info": {
+          "name": "Microsoft.Extensions.Primitives",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2",
+        "info": {
+          "name": "Microsoft.Extensions.DependencyInjection.Abstractions",
+          "version": "8.0.2"
         }
       },
       {
@@ -121,6 +93,34 @@
         "id": "Microsoft.Extensions.Logging.Abstractions@8.0.2",
         "info": {
           "name": "Microsoft.Extensions.Logging.Abstractions",
+          "version": "8.0.2"
+        }
+      },
+      {
+        "id": "RabbitMQ.Client@6.8.1",
+        "info": {
+          "name": "RabbitMQ.Client",
+          "version": "6.8.1"
+        }
+      },
+      {
+        "id": "System.Memory@8.0.0",
+        "info": {
+          "name": "System.Memory",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Threading.Channels@7.0.0",
+        "info": {
+          "name": "System.Threading.Channels",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Configuration.Binder@8.0.2",
+        "info": {
+          "name": "Microsoft.Extensions.Configuration.Binder",
           "version": "8.0.2"
         }
       },
@@ -250,6 +250,9 @@
             },
             {
               "nodeId": "Polly.Core@8.4.2"
+            },
+            {
+              "nodeId": "RabbitMQ.Client@6.8.1"
             }
           ]
         },
@@ -258,69 +261,12 @@
           "pkgId": "AspNetCore.HealthChecks.Rabbitmq@8.0.2",
           "deps": [
             {
+              "nodeId": "Microsoft.Extensions.Diagnostics.HealthChecks@8.0.10"
+            },
+            {
               "nodeId": "RabbitMQ.Client@6.8.1"
             }
           ]
-        },
-        {
-          "nodeId": "RabbitMQ.Client@6.8.1",
-          "pkgId": "RabbitMQ.Client@6.8.1",
-          "deps": [
-            {
-              "nodeId": "System.Memory@4.5.5"
-            },
-            {
-              "nodeId": "System.Threading.Channels@7.0.0"
-            }
-          ]
-        },
-        {
-          "nodeId": "System.Memory@4.5.5",
-          "pkgId": "System.Memory@8.0.0",
-          "deps": []
-        },
-        {
-          "nodeId": "System.Threading.Channels@7.0.0",
-          "pkgId": "System.Threading.Channels@7.0.0",
-          "deps": []
-        },
-        {
-          "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
-          "pkgId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
-          "deps": [
-            {
-              "nodeId": "Microsoft.Extensions.Primitives@8.0.0"
-            }
-          ]
-        },
-        {
-          "nodeId": "Microsoft.Extensions.Primitives@8.0.0",
-          "pkgId": "Microsoft.Extensions.Primitives@8.0.0",
-          "deps": []
-        },
-        {
-          "nodeId": "Microsoft.Extensions.Configuration.Binder@8.0.2",
-          "pkgId": "Microsoft.Extensions.Configuration.Binder@8.0.2",
-          "deps": [
-            {
-              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned"
-            }
-          ]
-        },
-        {
-          "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned",
-          "pkgId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
-          "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2",
-          "pkgId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2",
-          "deps": []
         },
         {
           "nodeId": "Microsoft.Extensions.Diagnostics.HealthChecks@8.0.10",
@@ -350,10 +296,10 @@
           "pkgId": "Microsoft.Extensions.Hosting.Abstractions@8.0.1",
           "deps": [
             {
-              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned"
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0"
             },
             {
-              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2"
             },
             {
               "nodeId": "Microsoft.Extensions.Diagnostics.Abstractions@8.0.1"
@@ -363,6 +309,46 @@
             },
             {
               "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
+          "pkgId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@8.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Primitives@8.0.0",
+          "pkgId": "Microsoft.Extensions.Primitives@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2",
+          "pkgId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Diagnostics.Abstractions@8.0.1",
+          "pkgId": "Microsoft.Extensions.Diagnostics.Abstractions@8.0.1",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2:pruned"
             }
           ]
         },
@@ -377,23 +363,17 @@
           }
         },
         {
-          "nodeId": "Microsoft.Extensions.Diagnostics.Abstractions@8.0.1",
-          "pkgId": "Microsoft.Extensions.Diagnostics.Abstractions@8.0.1",
+          "nodeId": "Microsoft.Extensions.Options@8.0.2",
+          "pkgId": "Microsoft.Extensions.Options@8.0.2",
           "deps": [
             {
               "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
             },
             {
-              "nodeId": "Microsoft.Extensions.Options@8.0.2"
-            }
-          ]
-        },
-        {
-          "nodeId": "Microsoft.Extensions.Options@8.0.2",
-          "pkgId": "Microsoft.Extensions.Options@8.0.2",
-          "deps": [
-            {
               "nodeId": "Microsoft.Extensions.Primitives@8.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2"
             }
           ]
         },
@@ -412,22 +392,82 @@
           "deps": [
             {
               "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2"
             }
           ]
+        },
+        {
+          "nodeId": "RabbitMQ.Client@6.8.1",
+          "pkgId": "RabbitMQ.Client@6.8.1",
+          "deps": [
+            {
+              "nodeId": "System.Memory@4.5.5"
+            },
+            {
+              "nodeId": "System.Threading.Channels@7.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Memory@4.5.5",
+          "pkgId": "System.Memory@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Threading.Channels@7.0.0",
+          "pkgId": "System.Threading.Channels@7.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.Binder@8.0.2",
+          "pkgId": "Microsoft.Extensions.Configuration.Binder@8.0.2",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned",
+          "pkgId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
         },
         {
           "nodeId": "OpenTelemetry.Extensions.Hosting@1.9.0",
           "pkgId": "OpenTelemetry.Extensions.Hosting@1.9.0",
           "deps": [
             {
+              "nodeId": "Microsoft.Extensions.Hosting.Abstractions@8.0.1:pruned"
+            },
+            {
               "nodeId": "OpenTelemetry@1.9.0"
             }
           ]
         },
         {
+          "nodeId": "Microsoft.Extensions.Hosting.Abstractions@8.0.1:pruned",
+          "pkgId": "Microsoft.Extensions.Hosting.Abstractions@8.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
           "nodeId": "OpenTelemetry@1.9.0",
           "pkgId": "OpenTelemetry@1.9.0",
           "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Diagnostics.Abstractions@8.0.1"
+            },
             {
               "nodeId": "Microsoft.Extensions.Logging.Configuration@8.0.0"
             },
@@ -435,6 +475,16 @@
               "nodeId": "OpenTelemetry.Api.ProviderBuilderExtensions@1.9.0"
             }
           ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Options@8.0.2:pruned",
+          "pkgId": "Microsoft.Extensions.Options@8.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
         },
         {
           "nodeId": "Microsoft.Extensions.Logging.Configuration@8.0.0",
@@ -447,7 +497,19 @@
               "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned"
             },
             {
+              "nodeId": "Microsoft.Extensions.Configuration.Binder@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            },
+            {
               "nodeId": "Microsoft.Extensions.Logging@8.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2:pruned"
             },
             {
               "nodeId": "Microsoft.Extensions.Options.ConfigurationExtensions@8.0.0"
@@ -477,18 +539,48 @@
           }
         },
         {
+          "nodeId": "Microsoft.Extensions.Configuration.Binder@8.0.2:pruned",
+          "pkgId": "Microsoft.Extensions.Configuration.Binder@8.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
           "nodeId": "Microsoft.Extensions.Logging@8.0.0",
           "pkgId": "Microsoft.Extensions.Logging@8.0.0",
           "deps": [
             {
               "nodeId": "Microsoft.Extensions.DependencyInjection@8.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2:pruned"
             }
           ]
         },
         {
           "nodeId": "Microsoft.Extensions.DependencyInjection@8.0.0",
           "pkgId": "Microsoft.Extensions.DependencyInjection@8.0.0",
-          "deps": []
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2:pruned",
+          "pkgId": "Microsoft.Extensions.Logging.Abstractions@8.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
         },
         {
           "nodeId": "Microsoft.Extensions.Options.ConfigurationExtensions@8.0.0",
@@ -496,6 +588,15 @@
           "deps": [
             {
               "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Binder@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2:pruned"
             },
             {
               "nodeId": "Microsoft.Extensions.Primitives@8.0.0:pruned"
@@ -506,6 +607,9 @@
           "nodeId": "OpenTelemetry.Api.ProviderBuilderExtensions@1.9.0",
           "pkgId": "OpenTelemetry.Api.ProviderBuilderExtensions@1.9.0",
           "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            },
             {
               "nodeId": "OpenTelemetry.Api@1.9.0"
             }

--- a/test/fixtures/dotnetcore/dotnet_8_false_positive/FirstProject/expected_depgraph-v3.json
+++ b/test/fixtures/dotnetcore/dotnet_8_false_positive/FirstProject/expected_depgraph-v3.json
@@ -27,55 +27,6 @@
         }
       },
       {
-        "id": "RabbitMQ.Client@6.8.1",
-        "info": {
-          "name": "RabbitMQ.Client",
-          "version": "6.8.1"
-        }
-      },
-      {
-        "id": "System.Memory@4.5.5",
-        "info": {
-          "name": "System.Memory",
-          "version": "4.5.5"
-        }
-      },
-      {
-        "id": "System.Threading.Channels@7.0.0",
-        "info": {
-          "name": "System.Threading.Channels",
-          "version": "7.0.0"
-        }
-      },
-      {
-        "id": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
-        "info": {
-          "name": "Microsoft.Extensions.Configuration.Abstractions",
-          "version": "8.0.0"
-        }
-      },
-      {
-        "id": "Microsoft.Extensions.Primitives@8.0.0",
-        "info": {
-          "name": "Microsoft.Extensions.Primitives",
-          "version": "8.0.0"
-        }
-      },
-      {
-        "id": "Microsoft.Extensions.Configuration.Binder@8.0.2",
-        "info": {
-          "name": "Microsoft.Extensions.Configuration.Binder",
-          "version": "8.0.2"
-        }
-      },
-      {
-        "id": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2",
-        "info": {
-          "name": "Microsoft.Extensions.DependencyInjection.Abstractions",
-          "version": "8.0.2"
-        }
-      },
-      {
         "id": "Microsoft.Extensions.Diagnostics.HealthChecks@8.0.10",
         "info": {
           "name": "Microsoft.Extensions.Diagnostics.HealthChecks",
@@ -94,6 +45,27 @@
         "info": {
           "name": "Microsoft.Extensions.Hosting.Abstractions",
           "version": "8.0.1"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
+        "info": {
+          "name": "Microsoft.Extensions.Configuration.Abstractions",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Primitives@8.0.0",
+        "info": {
+          "name": "Microsoft.Extensions.Primitives",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2",
+        "info": {
+          "name": "Microsoft.Extensions.DependencyInjection.Abstractions",
+          "version": "8.0.2"
         }
       },
       {
@@ -121,6 +93,34 @@
         "id": "Microsoft.Extensions.Logging.Abstractions@8.0.2",
         "info": {
           "name": "Microsoft.Extensions.Logging.Abstractions",
+          "version": "8.0.2"
+        }
+      },
+      {
+        "id": "RabbitMQ.Client@6.8.1",
+        "info": {
+          "name": "RabbitMQ.Client",
+          "version": "6.8.1"
+        }
+      },
+      {
+        "id": "System.Memory@4.5.5",
+        "info": {
+          "name": "System.Memory",
+          "version": "4.5.5"
+        }
+      },
+      {
+        "id": "System.Threading.Channels@7.0.0",
+        "info": {
+          "name": "System.Threading.Channels",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Configuration.Binder@8.0.2",
+        "info": {
+          "name": "Microsoft.Extensions.Configuration.Binder",
           "version": "8.0.2"
         }
       },
@@ -284,6 +284,9 @@
             },
             {
               "nodeId": "Polly.Core@8.4.2"
+            },
+            {
+              "nodeId": "RabbitMQ.Client@6.8.1"
             }
           ]
         },
@@ -292,69 +295,12 @@
           "pkgId": "AspNetCore.HealthChecks.Rabbitmq@8.0.2",
           "deps": [
             {
+              "nodeId": "Microsoft.Extensions.Diagnostics.HealthChecks@8.0.10"
+            },
+            {
               "nodeId": "RabbitMQ.Client@6.8.1"
             }
           ]
-        },
-        {
-          "nodeId": "RabbitMQ.Client@6.8.1",
-          "pkgId": "RabbitMQ.Client@6.8.1",
-          "deps": [
-            {
-              "nodeId": "System.Memory@4.5.5"
-            },
-            {
-              "nodeId": "System.Threading.Channels@7.0.0"
-            }
-          ]
-        },
-        {
-          "nodeId": "System.Memory@4.5.5",
-          "pkgId": "System.Memory@4.5.5",
-          "deps": []
-        },
-        {
-          "nodeId": "System.Threading.Channels@7.0.0",
-          "pkgId": "System.Threading.Channels@7.0.0",
-          "deps": []
-        },
-        {
-          "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
-          "pkgId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
-          "deps": [
-            {
-              "nodeId": "Microsoft.Extensions.Primitives@8.0.0"
-            }
-          ]
-        },
-        {
-          "nodeId": "Microsoft.Extensions.Primitives@8.0.0",
-          "pkgId": "Microsoft.Extensions.Primitives@8.0.0",
-          "deps": []
-        },
-        {
-          "nodeId": "Microsoft.Extensions.Configuration.Binder@8.0.2",
-          "pkgId": "Microsoft.Extensions.Configuration.Binder@8.0.2",
-          "deps": [
-            {
-              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned"
-            }
-          ]
-        },
-        {
-          "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned",
-          "pkgId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
-          "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2",
-          "pkgId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2",
-          "deps": []
         },
         {
           "nodeId": "Microsoft.Extensions.Diagnostics.HealthChecks@8.0.10",
@@ -384,10 +330,10 @@
           "pkgId": "Microsoft.Extensions.Hosting.Abstractions@8.0.1",
           "deps": [
             {
-              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned"
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0"
             },
             {
-              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2"
             },
             {
               "nodeId": "Microsoft.Extensions.Diagnostics.Abstractions@8.0.1"
@@ -397,6 +343,46 @@
             },
             {
               "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
+          "pkgId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@8.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Primitives@8.0.0",
+          "pkgId": "Microsoft.Extensions.Primitives@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2",
+          "pkgId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Diagnostics.Abstractions@8.0.1",
+          "pkgId": "Microsoft.Extensions.Diagnostics.Abstractions@8.0.1",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2:pruned"
             }
           ]
         },
@@ -411,23 +397,17 @@
           }
         },
         {
-          "nodeId": "Microsoft.Extensions.Diagnostics.Abstractions@8.0.1",
-          "pkgId": "Microsoft.Extensions.Diagnostics.Abstractions@8.0.1",
+          "nodeId": "Microsoft.Extensions.Options@8.0.2",
+          "pkgId": "Microsoft.Extensions.Options@8.0.2",
           "deps": [
             {
               "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
             },
             {
-              "nodeId": "Microsoft.Extensions.Options@8.0.2"
-            }
-          ]
-        },
-        {
-          "nodeId": "Microsoft.Extensions.Options@8.0.2",
-          "pkgId": "Microsoft.Extensions.Options@8.0.2",
-          "deps": [
-            {
               "nodeId": "Microsoft.Extensions.Primitives@8.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2"
             }
           ]
         },
@@ -446,22 +426,82 @@
           "deps": [
             {
               "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2"
             }
           ]
+        },
+        {
+          "nodeId": "RabbitMQ.Client@6.8.1",
+          "pkgId": "RabbitMQ.Client@6.8.1",
+          "deps": [
+            {
+              "nodeId": "System.Memory@4.5.5"
+            },
+            {
+              "nodeId": "System.Threading.Channels@7.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Memory@4.5.5",
+          "pkgId": "System.Memory@4.5.5",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Threading.Channels@7.0.0",
+          "pkgId": "System.Threading.Channels@7.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.Binder@8.0.2",
+          "pkgId": "Microsoft.Extensions.Configuration.Binder@8.0.2",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned",
+          "pkgId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
         },
         {
           "nodeId": "OpenTelemetry.Extensions.Hosting@1.9.0",
           "pkgId": "OpenTelemetry.Extensions.Hosting@1.9.0",
           "deps": [
             {
+              "nodeId": "Microsoft.Extensions.Hosting.Abstractions@8.0.1:pruned"
+            },
+            {
               "nodeId": "OpenTelemetry@1.9.0"
             }
           ]
         },
         {
+          "nodeId": "Microsoft.Extensions.Hosting.Abstractions@8.0.1:pruned",
+          "pkgId": "Microsoft.Extensions.Hosting.Abstractions@8.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
           "nodeId": "OpenTelemetry@1.9.0",
           "pkgId": "OpenTelemetry@1.9.0",
           "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Diagnostics.Abstractions@8.0.1"
+            },
             {
               "nodeId": "Microsoft.Extensions.Logging.Configuration@8.0.0"
             },
@@ -469,6 +509,16 @@
               "nodeId": "OpenTelemetry.Api.ProviderBuilderExtensions@1.9.0"
             }
           ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Options@8.0.2:pruned",
+          "pkgId": "Microsoft.Extensions.Options@8.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
         },
         {
           "nodeId": "Microsoft.Extensions.Logging.Configuration@8.0.0",
@@ -481,7 +531,19 @@
               "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned"
             },
             {
+              "nodeId": "Microsoft.Extensions.Configuration.Binder@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            },
+            {
               "nodeId": "Microsoft.Extensions.Logging@8.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2:pruned"
             },
             {
               "nodeId": "Microsoft.Extensions.Options.ConfigurationExtensions@8.0.0"
@@ -511,18 +573,48 @@
           }
         },
         {
+          "nodeId": "Microsoft.Extensions.Configuration.Binder@8.0.2:pruned",
+          "pkgId": "Microsoft.Extensions.Configuration.Binder@8.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
           "nodeId": "Microsoft.Extensions.Logging@8.0.0",
           "pkgId": "Microsoft.Extensions.Logging@8.0.0",
           "deps": [
             {
               "nodeId": "Microsoft.Extensions.DependencyInjection@8.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2:pruned"
             }
           ]
         },
         {
           "nodeId": "Microsoft.Extensions.DependencyInjection@8.0.0",
           "pkgId": "Microsoft.Extensions.DependencyInjection@8.0.0",
-          "deps": []
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2:pruned",
+          "pkgId": "Microsoft.Extensions.Logging.Abstractions@8.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
         },
         {
           "nodeId": "Microsoft.Extensions.Options.ConfigurationExtensions@8.0.0",
@@ -530,6 +622,15 @@
           "deps": [
             {
               "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Binder@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2:pruned"
             },
             {
               "nodeId": "Microsoft.Extensions.Primitives@8.0.0:pruned"
@@ -540,6 +641,9 @@
           "nodeId": "OpenTelemetry.Api.ProviderBuilderExtensions@1.9.0",
           "pkgId": "OpenTelemetry.Api.ProviderBuilderExtensions@1.9.0",
           "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            },
             {
               "nodeId": "OpenTelemetry.Api@1.9.0"
             }
@@ -584,6 +688,9 @@
           "deps": [
             {
               "nodeId": "System.Formats.Asn1@8.0.1"
+            },
+            {
+              "nodeId": "System.Text.Json@8.0.4:pruned"
             }
           ]
         },
@@ -591,6 +698,16 @@
           "nodeId": "System.Formats.Asn1@8.0.1",
           "pkgId": "System.Formats.Asn1@8.0.1",
           "deps": []
+        },
+        {
+          "nodeId": "System.Text.Json@8.0.4:pruned",
+          "pkgId": "System.Text.Json@8.0.4",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
         }
       ]
     }

--- a/test/fixtures/dotnetcore/dotnet_8_publish_single_file/expected_depgraph-v3.json
+++ b/test/fixtures/dotnetcore/dotnet_8_publish_single_file/expected_depgraph-v3.json
@@ -118,6 +118,13 @@
         }
       },
       {
+        "id": "System.Security.Cryptography.ProtectedData@8.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.ProtectedData",
+          "version": "8.0.0"
+        }
+      },
+      {
         "id": "System.Memory@4.5.4",
         "info": {
           "name": "System.Memory",
@@ -237,13 +244,6 @@
         }
       },
       {
-        "id": "System.Security.Cryptography.ProtectedData@8.0.0",
-        "info": {
-          "name": "System.Security.Cryptography.ProtectedData",
-          "version": "8.0.0"
-        }
-      },
-      {
         "id": "System.Runtime.Caching@8.0.0",
         "info": {
           "name": "System.Runtime.Caching",
@@ -320,6 +320,9 @@
               "nodeId": "System.Memory@4.5.4"
             },
             {
+              "nodeId": "System.Security.Cryptography.ProtectedData@8.0.0"
+            },
+            {
               "nodeId": "System.Text.Json@4.7.2"
             },
             {
@@ -380,6 +383,9 @@
           "deps": [
             {
               "nodeId": "System.Text.Encodings.Web@4.7.2"
+            },
+            {
+              "nodeId": "System.Text.Json@4.7.2"
             }
           ]
         },
@@ -440,6 +446,9 @@
           "deps": [
             {
               "nodeId": "Microsoft.Identity.Client@4.60.3:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.ProtectedData@8.0.0"
             }
           ]
         },
@@ -452,6 +461,11 @@
               "pruned": "true"
             }
           }
+        },
+        {
+          "nodeId": "System.Security.Cryptography.ProtectedData@8.0.0",
+          "pkgId": "System.Security.Cryptography.ProtectedData@8.0.0",
+          "deps": []
         },
         {
           "nodeId": "System.Memory@4.5.4",
@@ -651,11 +665,6 @@
         {
           "nodeId": "System.Diagnostics.EventLog@8.0.0",
           "pkgId": "System.Diagnostics.EventLog@8.0.0",
-          "deps": []
-        },
-        {
-          "nodeId": "System.Security.Cryptography.ProtectedData@8.0.0",
-          "pkgId": "System.Security.Cryptography.ProtectedData@8.0.0",
           "deps": []
         },
         {

--- a/test/fixtures/dotnetcore/dotnet_8_transitive_false_positive/FirstProject/expected_depgraph-v3.json
+++ b/test/fixtures/dotnetcore/dotnet_8_transitive_false_positive/FirstProject/expected_depgraph-v3.json
@@ -27,55 +27,6 @@
         }
       },
       {
-        "id": "RabbitMQ.Client@6.8.1",
-        "info": {
-          "name": "RabbitMQ.Client",
-          "version": "6.8.1"
-        }
-      },
-      {
-        "id": "System.Memory@4.5.5",
-        "info": {
-          "name": "System.Memory",
-          "version": "4.5.5"
-        }
-      },
-      {
-        "id": "System.Threading.Channels@7.0.0",
-        "info": {
-          "name": "System.Threading.Channels",
-          "version": "7.0.0"
-        }
-      },
-      {
-        "id": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
-        "info": {
-          "name": "Microsoft.Extensions.Configuration.Abstractions",
-          "version": "8.0.0"
-        }
-      },
-      {
-        "id": "Microsoft.Extensions.Primitives@8.0.0",
-        "info": {
-          "name": "Microsoft.Extensions.Primitives",
-          "version": "8.0.0"
-        }
-      },
-      {
-        "id": "Microsoft.Extensions.Configuration.Binder@8.0.2",
-        "info": {
-          "name": "Microsoft.Extensions.Configuration.Binder",
-          "version": "8.0.2"
-        }
-      },
-      {
-        "id": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2",
-        "info": {
-          "name": "Microsoft.Extensions.DependencyInjection.Abstractions",
-          "version": "8.0.2"
-        }
-      },
-      {
         "id": "Microsoft.Extensions.Diagnostics.HealthChecks@8.0.10",
         "info": {
           "name": "Microsoft.Extensions.Diagnostics.HealthChecks",
@@ -94,6 +45,27 @@
         "info": {
           "name": "Microsoft.Extensions.Hosting.Abstractions",
           "version": "8.0.1"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
+        "info": {
+          "name": "Microsoft.Extensions.Configuration.Abstractions",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Primitives@8.0.0",
+        "info": {
+          "name": "Microsoft.Extensions.Primitives",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2",
+        "info": {
+          "name": "Microsoft.Extensions.DependencyInjection.Abstractions",
+          "version": "8.0.2"
         }
       },
       {
@@ -125,6 +97,34 @@
         }
       },
       {
+        "id": "RabbitMQ.Client@6.8.1",
+        "info": {
+          "name": "RabbitMQ.Client",
+          "version": "6.8.1"
+        }
+      },
+      {
+        "id": "System.Memory@4.5.5",
+        "info": {
+          "name": "System.Memory",
+          "version": "4.5.5"
+        }
+      },
+      {
+        "id": "System.Threading.Channels@7.0.0",
+        "info": {
+          "name": "System.Threading.Channels",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Configuration.Binder@8.0.2",
+        "info": {
+          "name": "Microsoft.Extensions.Configuration.Binder",
+          "version": "8.0.2"
+        }
+      },
+      {
         "id": "OpenTelemetry.Extensions.Hosting@1.9.0",
         "info": {
           "name": "OpenTelemetry.Extensions.Hosting",
@@ -150,6 +150,20 @@
         "info": {
           "name": "Microsoft.Extensions.Configuration",
           "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Logging@8.0.1",
+        "info": {
+          "name": "Microsoft.Extensions.Logging",
+          "version": "8.0.1"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.DependencyInjection@8.0.1",
+        "info": {
+          "name": "Microsoft.Extensions.DependencyInjection",
+          "version": "8.0.1"
         }
       },
       {
@@ -228,20 +242,6 @@
           "name": "Microsoft.Extensions.Caching.Abstractions",
           "version": "8.0.0"
         }
-      },
-      {
-        "id": "Microsoft.Extensions.Logging@8.0.1",
-        "info": {
-          "name": "Microsoft.Extensions.Logging",
-          "version": "8.0.1"
-        }
-      },
-      {
-        "id": "Microsoft.Extensions.DependencyInjection@8.0.1",
-        "info": {
-          "name": "Microsoft.Extensions.DependencyInjection",
-          "version": "8.0.1"
-        }
       }
     ],
     "graph": {
@@ -295,6 +295,9 @@
             },
             {
               "nodeId": "Polly.Core@8.4.2"
+            },
+            {
+              "nodeId": "RabbitMQ.Client@6.8.1"
             }
           ]
         },
@@ -303,69 +306,12 @@
           "pkgId": "AspNetCore.HealthChecks.Rabbitmq@8.0.2",
           "deps": [
             {
+              "nodeId": "Microsoft.Extensions.Diagnostics.HealthChecks@8.0.10"
+            },
+            {
               "nodeId": "RabbitMQ.Client@6.8.1"
             }
           ]
-        },
-        {
-          "nodeId": "RabbitMQ.Client@6.8.1",
-          "pkgId": "RabbitMQ.Client@6.8.1",
-          "deps": [
-            {
-              "nodeId": "System.Memory@4.5.5"
-            },
-            {
-              "nodeId": "System.Threading.Channels@7.0.0"
-            }
-          ]
-        },
-        {
-          "nodeId": "System.Memory@4.5.5",
-          "pkgId": "System.Memory@4.5.5",
-          "deps": []
-        },
-        {
-          "nodeId": "System.Threading.Channels@7.0.0",
-          "pkgId": "System.Threading.Channels@7.0.0",
-          "deps": []
-        },
-        {
-          "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
-          "pkgId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
-          "deps": [
-            {
-              "nodeId": "Microsoft.Extensions.Primitives@8.0.0"
-            }
-          ]
-        },
-        {
-          "nodeId": "Microsoft.Extensions.Primitives@8.0.0",
-          "pkgId": "Microsoft.Extensions.Primitives@8.0.0",
-          "deps": []
-        },
-        {
-          "nodeId": "Microsoft.Extensions.Configuration.Binder@8.0.2",
-          "pkgId": "Microsoft.Extensions.Configuration.Binder@8.0.2",
-          "deps": [
-            {
-              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned"
-            }
-          ]
-        },
-        {
-          "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned",
-          "pkgId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
-          "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2",
-          "pkgId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2",
-          "deps": []
         },
         {
           "nodeId": "Microsoft.Extensions.Diagnostics.HealthChecks@8.0.10",
@@ -395,10 +341,10 @@
           "pkgId": "Microsoft.Extensions.Hosting.Abstractions@8.0.1",
           "deps": [
             {
-              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned"
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0"
             },
             {
-              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2"
             },
             {
               "nodeId": "Microsoft.Extensions.Diagnostics.Abstractions@8.0.1"
@@ -408,6 +354,46 @@
             },
             {
               "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
+          "pkgId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@8.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Primitives@8.0.0",
+          "pkgId": "Microsoft.Extensions.Primitives@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2",
+          "pkgId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Diagnostics.Abstractions@8.0.1",
+          "pkgId": "Microsoft.Extensions.Diagnostics.Abstractions@8.0.1",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2:pruned"
             }
           ]
         },
@@ -422,23 +408,17 @@
           }
         },
         {
-          "nodeId": "Microsoft.Extensions.Diagnostics.Abstractions@8.0.1",
-          "pkgId": "Microsoft.Extensions.Diagnostics.Abstractions@8.0.1",
+          "nodeId": "Microsoft.Extensions.Options@8.0.2",
+          "pkgId": "Microsoft.Extensions.Options@8.0.2",
           "deps": [
             {
               "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
             },
             {
-              "nodeId": "Microsoft.Extensions.Options@8.0.2"
-            }
-          ]
-        },
-        {
-          "nodeId": "Microsoft.Extensions.Options@8.0.2",
-          "pkgId": "Microsoft.Extensions.Options@8.0.2",
-          "deps": [
-            {
               "nodeId": "Microsoft.Extensions.Primitives@8.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2"
             }
           ]
         },
@@ -464,18 +444,75 @@
           ]
         },
         {
+          "nodeId": "RabbitMQ.Client@6.8.1",
+          "pkgId": "RabbitMQ.Client@6.8.1",
+          "deps": [
+            {
+              "nodeId": "System.Memory@4.5.5"
+            },
+            {
+              "nodeId": "System.Threading.Channels@7.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Memory@4.5.5",
+          "pkgId": "System.Memory@4.5.5",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Threading.Channels@7.0.0",
+          "pkgId": "System.Threading.Channels@7.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.Binder@8.0.2",
+          "pkgId": "Microsoft.Extensions.Configuration.Binder@8.0.2",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned",
+          "pkgId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
           "nodeId": "OpenTelemetry.Extensions.Hosting@1.9.0",
           "pkgId": "OpenTelemetry.Extensions.Hosting@1.9.0",
           "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Hosting.Abstractions@8.0.1:pruned"
+            },
             {
               "nodeId": "OpenTelemetry@1.9.0"
             }
           ]
         },
         {
+          "nodeId": "Microsoft.Extensions.Hosting.Abstractions@8.0.1:pruned",
+          "pkgId": "Microsoft.Extensions.Hosting.Abstractions@8.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
           "nodeId": "OpenTelemetry@1.9.0",
           "pkgId": "OpenTelemetry@1.9.0",
           "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Diagnostics.Abstractions@8.0.1"
+            },
             {
               "nodeId": "Microsoft.Extensions.Logging.Configuration@8.0.0"
             },
@@ -483,6 +520,16 @@
               "nodeId": "OpenTelemetry.Api.ProviderBuilderExtensions@1.9.0"
             }
           ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Options@8.0.2:pruned",
+          "pkgId": "Microsoft.Extensions.Options@8.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
         },
         {
           "nodeId": "Microsoft.Extensions.Logging.Configuration@8.0.0",
@@ -493,6 +540,21 @@
             },
             {
               "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Binder@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging@8.0.1"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2:pruned"
             },
             {
               "nodeId": "Microsoft.Extensions.Options.ConfigurationExtensions@8.0.0"
@@ -522,11 +584,73 @@
           }
         },
         {
+          "nodeId": "Microsoft.Extensions.Configuration.Binder@8.0.2:pruned",
+          "pkgId": "Microsoft.Extensions.Configuration.Binder@8.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Logging@8.0.1",
+          "pkgId": "Microsoft.Extensions.Logging@8.0.1",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection@8.0.1"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.DependencyInjection@8.0.1",
+          "pkgId": "Microsoft.Extensions.DependencyInjection@8.0.1",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2:pruned",
+          "pkgId": "Microsoft.Extensions.Logging.Abstractions@8.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
           "nodeId": "Microsoft.Extensions.Options.ConfigurationExtensions@8.0.0",
           "pkgId": "Microsoft.Extensions.Options.ConfigurationExtensions@8.0.0",
           "deps": [
             {
               "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Binder@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2:pruned"
             },
             {
               "nodeId": "Microsoft.Extensions.Primitives@8.0.0:pruned"
@@ -537,6 +661,9 @@
           "nodeId": "OpenTelemetry.Api.ProviderBuilderExtensions@1.9.0",
           "pkgId": "OpenTelemetry.Api.ProviderBuilderExtensions@1.9.0",
           "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            },
             {
               "nodeId": "OpenTelemetry.Api@1.9.0"
             }
@@ -625,30 +752,6 @@
           "deps": [
             {
               "nodeId": "Microsoft.Extensions.Primitives@8.0.0"
-            }
-          ]
-        },
-        {
-          "nodeId": "Microsoft.Extensions.Logging@8.0.1",
-          "pkgId": "Microsoft.Extensions.Logging@8.0.1",
-          "deps": [
-            {
-              "nodeId": "Microsoft.Extensions.DependencyInjection@8.0.1"
-            },
-            {
-              "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2"
-            },
-            {
-              "nodeId": "Microsoft.Extensions.Options@8.0.2"
-            }
-          ]
-        },
-        {
-          "nodeId": "Microsoft.Extensions.DependencyInjection@8.0.1",
-          "pkgId": "Microsoft.Extensions.DependencyInjection@8.0.1",
-          "deps": [
-            {
-              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2"
             }
           ]
         }

--- a/test/fixtures/dotnetcore/dotnet_8_transitive_pinned_version/dotnet_8_transitive_pinned_version.csproj
+++ b/test/fixtures/dotnetcore/dotnet_8_transitive_pinned_version/dotnet_8_transitive_pinned_version.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Dynamicweb.Security" Version="12.5.21" />
+    <PackageReference Include="Aspire.RabbitMQ.Client" Version="8.2.2" />
+    <PackageReference Include="System.ServiceModel.Duplex" Version="[4.10.3]" />
+    <PackageReference
+      Include="Kentico.Xperience.Libraries"
+      Version="13.0.193"
+    />
+    <PackageReference
+      Include="System.ServiceModel.Syndication"
+      Version="(4.3.0, 4.7.0]"
+    />
+  </ItemGroup>
+</Project>

--- a/test/fixtures/dotnetcore/dotnet_8_transitive_pinned_version/expected_depgraph-v3.json
+++ b/test/fixtures/dotnetcore/dotnet_8_transitive_pinned_version/expected_depgraph-v3.json
@@ -1,0 +1,5949 @@
+{
+  "depGraph": {
+    "schemaVersion": "1.3.0",
+    "pkgManager": {
+      "name": "nuget"
+    },
+    "pkgs": [
+      {
+        "id": "dotnet_8_transitive_pinned_version@1.0.0",
+        "info": {
+          "name": "dotnet_8_transitive_pinned_version",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "Aspire.RabbitMQ.Client@8.2.2",
+        "info": {
+          "name": "Aspire.RabbitMQ.Client",
+          "version": "8.2.2"
+        }
+      },
+      {
+        "id": "AspNetCore.HealthChecks.Rabbitmq@8.0.2",
+        "info": {
+          "name": "AspNetCore.HealthChecks.Rabbitmq",
+          "version": "8.0.2"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Diagnostics.HealthChecks@8.0.10",
+        "info": {
+          "name": "Microsoft.Extensions.Diagnostics.HealthChecks",
+          "version": "8.0.10"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions@8.0.10",
+        "info": {
+          "name": "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions",
+          "version": "8.0.10"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Hosting.Abstractions@8.0.1",
+        "info": {
+          "name": "Microsoft.Extensions.Hosting.Abstractions",
+          "version": "8.0.1"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
+        "info": {
+          "name": "Microsoft.Extensions.Configuration.Abstractions",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Primitives@8.0.0",
+        "info": {
+          "name": "Microsoft.Extensions.Primitives",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2",
+        "info": {
+          "name": "Microsoft.Extensions.DependencyInjection.Abstractions",
+          "version": "8.0.2"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Diagnostics.Abstractions@8.0.1",
+        "info": {
+          "name": "Microsoft.Extensions.Diagnostics.Abstractions",
+          "version": "8.0.1"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Options@8.0.2",
+        "info": {
+          "name": "Microsoft.Extensions.Options",
+          "version": "8.0.2"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.FileProviders.Abstractions@8.0.0",
+        "info": {
+          "name": "Microsoft.Extensions.FileProviders.Abstractions",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Logging.Abstractions@8.0.2",
+        "info": {
+          "name": "Microsoft.Extensions.Logging.Abstractions",
+          "version": "8.0.2"
+        }
+      },
+      {
+        "id": "RabbitMQ.Client@6.8.1",
+        "info": {
+          "name": "RabbitMQ.Client",
+          "version": "6.8.1"
+        }
+      },
+      {
+        "id": "System.Memory@8.0.0",
+        "info": {
+          "name": "System.Memory",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Threading.Channels@7.0.0",
+        "info": {
+          "name": "System.Threading.Channels",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Configuration.Binder@8.0.2",
+        "info": {
+          "name": "Microsoft.Extensions.Configuration.Binder",
+          "version": "8.0.2"
+        }
+      },
+      {
+        "id": "OpenTelemetry.Extensions.Hosting@1.9.0",
+        "info": {
+          "name": "OpenTelemetry.Extensions.Hosting",
+          "version": "1.9.0"
+        }
+      },
+      {
+        "id": "OpenTelemetry@1.9.0",
+        "info": {
+          "name": "OpenTelemetry",
+          "version": "1.9.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Logging.Configuration@8.0.0",
+        "info": {
+          "name": "Microsoft.Extensions.Logging.Configuration",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Configuration@8.0.0",
+        "info": {
+          "name": "Microsoft.Extensions.Configuration",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Logging@8.0.0",
+        "info": {
+          "name": "Microsoft.Extensions.Logging",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.DependencyInjection@8.0.0",
+        "info": {
+          "name": "Microsoft.Extensions.DependencyInjection",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Options.ConfigurationExtensions@8.0.0",
+        "info": {
+          "name": "Microsoft.Extensions.Options.ConfigurationExtensions",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "OpenTelemetry.Api.ProviderBuilderExtensions@1.9.0",
+        "info": {
+          "name": "OpenTelemetry.Api.ProviderBuilderExtensions",
+          "version": "1.9.0"
+        }
+      },
+      {
+        "id": "OpenTelemetry.Api@1.9.0",
+        "info": {
+          "name": "OpenTelemetry.Api",
+          "version": "1.9.0"
+        }
+      },
+      {
+        "id": "System.Diagnostics.DiagnosticSource@8.0.0",
+        "info": {
+          "name": "System.Diagnostics.DiagnosticSource",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Polly.Core@8.4.2",
+        "info": {
+          "name": "Polly.Core",
+          "version": "8.4.2"
+        }
+      },
+      {
+        "id": "Dynamicweb.Security@12.5.21",
+        "info": {
+          "name": "Dynamicweb.Security",
+          "version": "12.5.21"
+        }
+      },
+      {
+        "id": "Dynamicweb.Caching@3.1.2",
+        "info": {
+          "name": "Dynamicweb.Caching",
+          "version": "3.1.2"
+        }
+      },
+      {
+        "id": "Dynamicweb.Core@4.1.1",
+        "info": {
+          "name": "Dynamicweb.Core",
+          "version": "4.1.1"
+        }
+      },
+      {
+        "id": "Newtonsoft.Json@13.0.3",
+        "info": {
+          "name": "Newtonsoft.Json",
+          "version": "13.0.3"
+        }
+      },
+      {
+        "id": "System.ComponentModel.Composition@4.7.0",
+        "info": {
+          "name": "System.ComponentModel.Composition",
+          "version": "4.7.0"
+        }
+      },
+      {
+        "id": "Dynamicweb.Extensibility@5.0.4",
+        "info": {
+          "name": "Dynamicweb.Extensibility",
+          "version": "5.0.4"
+        }
+      },
+      {
+        "id": "Dynamicweb.Core.UI@3.0.1",
+        "info": {
+          "name": "Dynamicweb.Core.UI",
+          "version": "3.0.1"
+        }
+      },
+      {
+        "id": "System.Reflection.Emit@8.0.0",
+        "info": {
+          "name": "System.Reflection.Emit",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Runtime.Caching@4.7.0",
+        "info": {
+          "name": "System.Runtime.Caching",
+          "version": "4.7.0"
+        }
+      },
+      {
+        "id": "System.Configuration.ConfigurationManager@4.7.0",
+        "info": {
+          "name": "System.Configuration.ConfigurationManager",
+          "version": "4.7.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.ProtectedData@4.7.0",
+        "info": {
+          "name": "System.Security.Cryptography.ProtectedData",
+          "version": "4.7.0"
+        }
+      },
+      {
+        "id": "System.Security.Permissions@5.0.0",
+        "info": {
+          "name": "System.Security.Permissions",
+          "version": "5.0.0"
+        }
+      },
+      {
+        "id": "System.Security.AccessControl@6.0.0",
+        "info": {
+          "name": "System.Security.AccessControl",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Windows.Extensions@5.0.0",
+        "info": {
+          "name": "System.Windows.Extensions",
+          "version": "5.0.0"
+        }
+      },
+      {
+        "id": "System.Drawing.Common@5.0.3",
+        "info": {
+          "name": "System.Drawing.Common",
+          "version": "5.0.3"
+        }
+      },
+      {
+        "id": "Microsoft.Win32.SystemEvents@5.0.0",
+        "info": {
+          "name": "Microsoft.Win32.SystemEvents",
+          "version": "5.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.NETCore.Platforms@5.0.0",
+        "info": {
+          "name": "Microsoft.NETCore.Platforms",
+          "version": "5.0.0"
+        }
+      },
+      {
+        "id": "Dynamicweb.Configuration@4.1.3",
+        "info": {
+          "name": "Dynamicweb.Configuration",
+          "version": "4.1.3"
+        }
+      },
+      {
+        "id": "Dynamicweb.Data@3.1.0",
+        "info": {
+          "name": "Dynamicweb.Data",
+          "version": "3.1.0"
+        }
+      },
+      {
+        "id": "Dynamicweb.Diagnostics@4.0.3",
+        "info": {
+          "name": "Dynamicweb.Diagnostics",
+          "version": "4.0.3"
+        }
+      },
+      {
+        "id": "Dynamicweb.Logging@6.0.3",
+        "info": {
+          "name": "Dynamicweb.Logging",
+          "version": "6.0.3"
+        }
+      },
+      {
+        "id": "NLog@4.5.0",
+        "info": {
+          "name": "NLog",
+          "version": "4.5.0"
+        }
+      },
+      {
+        "id": "EPPlus@5.6.3",
+        "info": {
+          "name": "EPPlus",
+          "version": "5.6.3"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Configuration.Json@5.0.0",
+        "info": {
+          "name": "Microsoft.Extensions.Configuration.Json",
+          "version": "5.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Configuration.FileExtensions@5.0.0",
+        "info": {
+          "name": "Microsoft.Extensions.Configuration.FileExtensions",
+          "version": "5.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.FileProviders.Physical@5.0.0",
+        "info": {
+          "name": "Microsoft.Extensions.FileProviders.Physical",
+          "version": "5.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.FileSystemGlobbing@5.0.0",
+        "info": {
+          "name": "Microsoft.Extensions.FileSystemGlobbing",
+          "version": "5.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.IO.RecyclableMemoryStream@1.4.1",
+        "info": {
+          "name": "Microsoft.IO.RecyclableMemoryStream",
+          "version": "1.4.1"
+        }
+      },
+      {
+        "id": "System.ComponentModel.Annotations@8.0.0",
+        "info": {
+          "name": "System.ComponentModel.Annotations",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.ComponentModel.TypeConverter@8.0.0",
+        "info": {
+          "name": "System.ComponentModel.TypeConverter",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Collections@8.0.0",
+        "info": {
+          "name": "System.Collections",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.NETCore.Targets@1.1.0",
+        "info": {
+          "name": "Microsoft.NETCore.Targets",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "id": "System.Runtime@8.0.0",
+        "info": {
+          "name": "System.Runtime",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Collections.NonGeneric@8.0.0",
+        "info": {
+          "name": "System.Collections.NonGeneric",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Diagnostics.Debug@8.0.0",
+        "info": {
+          "name": "System.Diagnostics.Debug",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Globalization@8.0.0",
+        "info": {
+          "name": "System.Globalization",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Resources.ResourceManager@8.0.0",
+        "info": {
+          "name": "System.Resources.ResourceManager",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection@8.0.0",
+        "info": {
+          "name": "System.Reflection",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.IO@8.0.0",
+        "info": {
+          "name": "System.IO",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Text.Encoding@8.0.0",
+        "info": {
+          "name": "System.Text.Encoding",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Threading.Tasks@8.0.0",
+        "info": {
+          "name": "System.Threading.Tasks",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection.Primitives@8.0.0",
+        "info": {
+          "name": "System.Reflection.Primitives",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Runtime.Extensions@8.0.0",
+        "info": {
+          "name": "System.Runtime.Extensions",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Threading@8.0.0",
+        "info": {
+          "name": "System.Threading",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Collections.Specialized@8.0.0",
+        "info": {
+          "name": "System.Collections.Specialized",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Globalization.Extensions@8.0.0",
+        "info": {
+          "name": "System.Globalization.Extensions",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Runtime.InteropServices@8.0.0",
+        "info": {
+          "name": "System.Runtime.InteropServices",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Runtime.Handles@8.0.0",
+        "info": {
+          "name": "System.Runtime.Handles",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.ComponentModel@8.0.0",
+        "info": {
+          "name": "System.ComponentModel",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.ComponentModel.Primitives@8.0.0",
+        "info": {
+          "name": "System.ComponentModel.Primitives",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Linq@8.0.0",
+        "info": {
+          "name": "System.Linq",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection.Extensions@8.0.0",
+        "info": {
+          "name": "System.Reflection.Extensions",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection.TypeExtensions@8.0.0",
+        "info": {
+          "name": "System.Reflection.TypeExtensions",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Data.Common@8.0.0",
+        "info": {
+          "name": "System.Data.Common",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Text.RegularExpressions@8.0.0",
+        "info": {
+          "name": "System.Text.RegularExpressions",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Security.Claims@8.0.0",
+        "info": {
+          "name": "System.Security.Claims",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Security.Principal@8.0.0",
+        "info": {
+          "name": "System.Security.Principal",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.Pkcs@8.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.Pkcs",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Formats.Asn1@8.0.1",
+        "info": {
+          "name": "System.Formats.Asn1",
+          "version": "8.0.1"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.X509Certificates@8.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.X509Certificates",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Globalization.Calendars@8.0.0",
+        "info": {
+          "name": "System.Globalization.Calendars",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.IO.FileSystem@8.0.0",
+        "info": {
+          "name": "System.IO.FileSystem",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.IO.FileSystem.Primitives@8.0.0",
+        "info": {
+          "name": "System.IO.FileSystem.Primitives",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Runtime.Numerics@8.0.0",
+        "info": {
+          "name": "System.Runtime.Numerics",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.Algorithms@8.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.Algorithms",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.Encoding@8.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.Encoding",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Collections.Concurrent@8.0.0",
+        "info": {
+          "name": "System.Collections.Concurrent",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Diagnostics.Tracing@8.0.0",
+        "info": {
+          "name": "System.Diagnostics.Tracing",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.Primitives@8.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.Primitives",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.Cng@8.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.Cng",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.Csp@8.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.Csp",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.OpenSsl@8.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.OpenSsl",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Text.Encoding.CodePages@6.0.0",
+        "info": {
+          "name": "System.Text.Encoding.CodePages",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Runtime.CompilerServices.Unsafe@6.0.0",
+        "info": {
+          "name": "System.Runtime.CompilerServices.Unsafe",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "System.Xml.XPath.XmlDocument@4.3.0",
+        "info": {
+          "name": "System.Xml.XPath.XmlDocument",
+          "version": "4.3.0"
+        }
+      },
+      {
+        "id": "System.Xml.ReaderWriter@8.0.0",
+        "info": {
+          "name": "System.Xml.ReaderWriter",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Text.Encoding.Extensions@8.0.0",
+        "info": {
+          "name": "System.Text.Encoding.Extensions",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Threading.Tasks.Extensions@8.0.0",
+        "info": {
+          "name": "System.Threading.Tasks.Extensions",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Xml.XPath@8.0.0",
+        "info": {
+          "name": "System.Xml.XPath",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Xml.XmlDocument@8.0.0",
+        "info": {
+          "name": "System.Xml.XmlDocument",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Data.OleDb@4.7.1",
+        "info": {
+          "name": "System.Data.OleDb",
+          "version": "4.7.1"
+        }
+      },
+      {
+        "id": "Microsoft.Win32.Registry@8.0.0",
+        "info": {
+          "name": "Microsoft.Win32.Registry",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Security.Principal.Windows@8.0.0",
+        "info": {
+          "name": "System.Security.Principal.Windows",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Diagnostics.PerformanceCounter@4.7.0",
+        "info": {
+          "name": "System.Diagnostics.PerformanceCounter",
+          "version": "4.7.0"
+        }
+      },
+      {
+        "id": "System.Data.SqlClient@4.8.6",
+        "info": {
+          "name": "System.Data.SqlClient",
+          "version": "4.8.6"
+        }
+      },
+      {
+        "id": "Dynamicweb.Environment@4.0.11",
+        "info": {
+          "name": "Dynamicweb.Environment",
+          "version": "4.0.11"
+        }
+      },
+      {
+        "id": "Dynamicweb.Mailing@5.0.6",
+        "info": {
+          "name": "Dynamicweb.Mailing",
+          "version": "5.0.6"
+        }
+      },
+      {
+        "id": "Dynamicweb.Updates@1.1.0",
+        "info": {
+          "name": "Dynamicweb.Updates",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "id": "HtmlAgilityPack@1.11.28",
+        "info": {
+          "name": "HtmlAgilityPack",
+          "version": "1.11.28"
+        }
+      },
+      {
+        "id": "System.DirectoryServices@5.0.0",
+        "info": {
+          "name": "System.DirectoryServices",
+          "version": "5.0.0"
+        }
+      },
+      {
+        "id": "System.IO.FileSystem.AccessControl@8.0.0",
+        "info": {
+          "name": "System.IO.FileSystem.AccessControl",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Net.Http.Json@5.0.0",
+        "info": {
+          "name": "System.Net.Http.Json",
+          "version": "5.0.0"
+        }
+      },
+      {
+        "id": "System.ServiceModel.Duplex@4.10.3",
+        "info": {
+          "name": "System.ServiceModel.Duplex",
+          "version": "4.10.3"
+        }
+      },
+      {
+        "id": "System.Private.ServiceModel@4.10.3",
+        "info": {
+          "name": "System.Private.ServiceModel",
+          "version": "4.10.3"
+        }
+      },
+      {
+        "id": "Microsoft.Bcl.AsyncInterfaces@5.0.0",
+        "info": {
+          "name": "Microsoft.Bcl.AsyncInterfaces",
+          "version": "5.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.ObjectPool@5.0.10",
+        "info": {
+          "name": "Microsoft.Extensions.ObjectPool",
+          "version": "5.0.10"
+        }
+      },
+      {
+        "id": "System.Numerics.Vectors@8.0.0",
+        "info": {
+          "name": "System.Numerics.Vectors",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection.DispatchProxy@4.7.1",
+        "info": {
+          "name": "System.Reflection.DispatchProxy",
+          "version": "4.7.1"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.Xml@6.0.1",
+        "info": {
+          "name": "System.Security.Cryptography.Xml",
+          "version": "6.0.1"
+        }
+      },
+      {
+        "id": "System.ServiceModel.Primitives@4.10.3",
+        "info": {
+          "name": "System.ServiceModel.Primitives",
+          "version": "4.10.3"
+        }
+      },
+      {
+        "id": "System.ServiceModel.Http@4.10.3",
+        "info": {
+          "name": "System.ServiceModel.Http",
+          "version": "4.10.3"
+        }
+      },
+      {
+        "id": "System.ServiceModel.NetTcp@4.10.3",
+        "info": {
+          "name": "System.ServiceModel.NetTcp",
+          "version": "4.10.3"
+        }
+      },
+      {
+        "id": "System.ServiceModel.Security@4.10.3",
+        "info": {
+          "name": "System.ServiceModel.Security",
+          "version": "4.10.3"
+        }
+      },
+      {
+        "id": "Kentico.Xperience.Libraries@13.0.193",
+        "info": {
+          "name": "Kentico.Xperience.Libraries",
+          "version": "13.0.193"
+        }
+      },
+      {
+        "id": "AWSSDK.Core@3.5.1.13",
+        "info": {
+          "name": "AWSSDK.Core",
+          "version": "3.5.1.13"
+        }
+      },
+      {
+        "id": "AWSSDK.S3@3.5.1.4",
+        "info": {
+          "name": "AWSSDK.S3",
+          "version": "3.5.1.4"
+        }
+      },
+      {
+        "id": "AngleSharp@0.17.1",
+        "info": {
+          "name": "AngleSharp",
+          "version": "0.17.1"
+        }
+      },
+      {
+        "id": "System.Buffers@8.0.0",
+        "info": {
+          "name": "System.Buffers",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Azure.AI.TextAnalytics@5.2.0",
+        "info": {
+          "name": "Azure.AI.TextAnalytics",
+          "version": "5.2.0"
+        }
+      },
+      {
+        "id": "Azure.Core@1.25.0",
+        "info": {
+          "name": "Azure.Core",
+          "version": "1.25.0"
+        }
+      },
+      {
+        "id": "System.Memory.Data@1.0.2",
+        "info": {
+          "name": "System.Memory.Data",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "id": "System.Text.Encodings.Web@4.7.2",
+        "info": {
+          "name": "System.Text.Encodings.Web",
+          "version": "4.7.2"
+        }
+      },
+      {
+        "id": "System.Text.Json@4.7.2",
+        "info": {
+          "name": "System.Text.Json",
+          "version": "4.7.2"
+        }
+      },
+      {
+        "id": "DocumentFormat.OpenXml@2.19.0",
+        "info": {
+          "name": "DocumentFormat.OpenXml",
+          "version": "2.19.0"
+        }
+      },
+      {
+        "id": "System.IO.Packaging@4.7.0",
+        "info": {
+          "name": "System.IO.Packaging",
+          "version": "4.7.0"
+        }
+      },
+      {
+        "id": "MailKit@4.7.1.1",
+        "info": {
+          "name": "MailKit",
+          "version": "4.7.1.1"
+        }
+      },
+      {
+        "id": "MimeKit@4.7.1",
+        "info": {
+          "name": "MimeKit",
+          "version": "4.7.1"
+        }
+      },
+      {
+        "id": "BouncyCastle.Cryptography@2.4.0",
+        "info": {
+          "name": "BouncyCastle.Cryptography",
+          "version": "2.4.0"
+        }
+      },
+      {
+        "id": "MaxMind.GeoIP2@3.2.0",
+        "info": {
+          "name": "MaxMind.GeoIP2",
+          "version": "3.2.0"
+        }
+      },
+      {
+        "id": "MaxMind.Db@2.6.1",
+        "info": {
+          "name": "MaxMind.Db",
+          "version": "2.6.1"
+        }
+      },
+      {
+        "id": "Microsoft.CSharp@8.0.0",
+        "info": {
+          "name": "Microsoft.CSharp",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Azure.CognitiveServices.Vision.ComputerVision@7.0.0",
+        "info": {
+          "name": "Microsoft.Azure.CognitiveServices.Vision.ComputerVision",
+          "version": "7.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Rest.ClientRuntime@2.3.24",
+        "info": {
+          "name": "Microsoft.Rest.ClientRuntime",
+          "version": "2.3.24"
+        }
+      },
+      {
+        "id": "Microsoft.Rest.ClientRuntime.Azure@3.3.18",
+        "info": {
+          "name": "Microsoft.Rest.ClientRuntime.Azure",
+          "version": "3.3.18"
+        }
+      },
+      {
+        "id": "NETStandard.Library@2.0.1",
+        "info": {
+          "name": "NETStandard.Library",
+          "version": "2.0.1"
+        }
+      },
+      {
+        "id": "System.Net.Http@8.0.0",
+        "info": {
+          "name": "System.Net.Http",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Net.Primitives@8.0.0",
+        "info": {
+          "name": "System.Net.Primitives",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Azure.Search@10.1.0",
+        "info": {
+          "name": "Microsoft.Azure.Search",
+          "version": "10.1.0"
+        }
+      },
+      {
+        "id": "Microsoft.Azure.Search.Data@10.1.0",
+        "info": {
+          "name": "Microsoft.Azure.Search.Data",
+          "version": "10.1.0"
+        }
+      },
+      {
+        "id": "Microsoft.Azure.Search.Common@10.1.0",
+        "info": {
+          "name": "Microsoft.Azure.Search.Common",
+          "version": "10.1.0"
+        }
+      },
+      {
+        "id": "Microsoft.Spatial@7.5.3",
+        "info": {
+          "name": "Microsoft.Spatial",
+          "version": "7.5.3"
+        }
+      },
+      {
+        "id": "Microsoft.Azure.Search.Service@10.1.0",
+        "info": {
+          "name": "Microsoft.Azure.Search.Service",
+          "version": "10.1.0"
+        }
+      },
+      {
+        "id": "Microsoft.Azure.Storage.Blob@11.2.2",
+        "info": {
+          "name": "Microsoft.Azure.Storage.Blob",
+          "version": "11.2.2"
+        }
+      },
+      {
+        "id": "Microsoft.Azure.Storage.Common@11.2.2",
+        "info": {
+          "name": "Microsoft.Azure.Storage.Common",
+          "version": "11.2.2"
+        }
+      },
+      {
+        "id": "Microsoft.Azure.KeyVault.Core@2.0.4",
+        "info": {
+          "name": "Microsoft.Azure.KeyVault.Core",
+          "version": "2.0.4"
+        }
+      },
+      {
+        "id": "Microsoft.Azure.Storage.Queue@11.2.2",
+        "info": {
+          "name": "Microsoft.Azure.Storage.Queue",
+          "version": "11.2.2"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Caching.Memory@3.1.8",
+        "info": {
+          "name": "Microsoft.Extensions.Caching.Memory",
+          "version": "3.1.8"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Caching.Abstractions@3.1.8",
+        "info": {
+          "name": "Microsoft.Extensions.Caching.Abstractions",
+          "version": "3.1.8"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Logging.Debug@3.1.8",
+        "info": {
+          "name": "Microsoft.Extensions.Logging.Debug",
+          "version": "3.1.8"
+        }
+      },
+      {
+        "id": "Microsoft.SqlServer.DacFx@150.4573.2",
+        "info": {
+          "name": "Microsoft.SqlServer.DacFx",
+          "version": "150.4573.2"
+        }
+      },
+      {
+        "id": "Microsoft.Build@15.9.20",
+        "info": {
+          "name": "Microsoft.Build",
+          "version": "15.9.20"
+        }
+      },
+      {
+        "id": "Microsoft.Build.Framework@15.9.20",
+        "info": {
+          "name": "Microsoft.Build.Framework",
+          "version": "15.9.20"
+        }
+      },
+      {
+        "id": "System.Runtime.Serialization.Primitives@8.0.0",
+        "info": {
+          "name": "System.Runtime.Serialization.Primitives",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Threading.Thread@8.0.0",
+        "info": {
+          "name": "System.Threading.Thread",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Collections.Immutable@1.5.0",
+        "info": {
+          "name": "System.Collections.Immutable",
+          "version": "1.5.0"
+        }
+      },
+      {
+        "id": "System.Diagnostics.TraceSource@8.0.0",
+        "info": {
+          "name": "System.Diagnostics.TraceSource",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.IO.Compression@8.0.0",
+        "info": {
+          "name": "System.IO.Compression",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection.Metadata@1.6.0",
+        "info": {
+          "name": "System.Reflection.Metadata",
+          "version": "1.6.0"
+        }
+      },
+      {
+        "id": "System.Runtime.InteropServices.RuntimeInformation@8.0.0",
+        "info": {
+          "name": "System.Runtime.InteropServices.RuntimeInformation",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Runtime.Loader@8.0.0",
+        "info": {
+          "name": "System.Runtime.Loader",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Threading.Tasks.Dataflow@4.6.0",
+        "info": {
+          "name": "System.Threading.Tasks.Dataflow",
+          "version": "4.6.0"
+        }
+      },
+      {
+        "id": "System.Dynamic.Runtime@8.0.0",
+        "info": {
+          "name": "System.Dynamic.Runtime",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Linq.Expressions@8.0.0",
+        "info": {
+          "name": "System.Linq.Expressions",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.ObjectModel@8.0.0",
+        "info": {
+          "name": "System.ObjectModel",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection.Emit.ILGeneration@8.0.0",
+        "info": {
+          "name": "System.Reflection.Emit.ILGeneration",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection.Emit.Lightweight@8.0.0",
+        "info": {
+          "name": "System.Reflection.Emit.Lightweight",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Threading.ThreadPool@8.0.0",
+        "info": {
+          "name": "System.Threading.ThreadPool",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Mono.Cecil@0.10.0",
+        "info": {
+          "name": "Mono.Cecil",
+          "version": "0.10.0"
+        }
+      },
+      {
+        "id": "NuGet.Packaging@5.11.6",
+        "info": {
+          "name": "NuGet.Packaging",
+          "version": "5.11.6"
+        }
+      },
+      {
+        "id": "NuGet.Configuration@5.11.6",
+        "info": {
+          "name": "NuGet.Configuration",
+          "version": "5.11.6"
+        }
+      },
+      {
+        "id": "NuGet.Common@5.11.6",
+        "info": {
+          "name": "NuGet.Common",
+          "version": "5.11.6"
+        }
+      },
+      {
+        "id": "NuGet.Frameworks@5.11.6",
+        "info": {
+          "name": "NuGet.Frameworks",
+          "version": "5.11.6"
+        }
+      },
+      {
+        "id": "NuGet.Versioning@5.11.6",
+        "info": {
+          "name": "NuGet.Versioning",
+          "version": "5.11.6"
+        }
+      },
+      {
+        "id": "PreMailer.Net@2.2.0",
+        "info": {
+          "name": "PreMailer.Net",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "System.CodeDom@4.5.0",
+        "info": {
+          "name": "System.CodeDom",
+          "version": "4.5.0"
+        }
+      },
+      {
+        "id": "System.Data.DataSetExtensions@8.0.0",
+        "info": {
+          "name": "System.Data.DataSetExtensions",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Data.HashFunction.CRC@2.0.0",
+        "info": {
+          "name": "System.Data.HashFunction.CRC",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "id": "System.Data.HashFunction.Core@2.0.0",
+        "info": {
+          "name": "System.Data.HashFunction.Core",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "id": "System.Data.HashFunction.Interfaces@2.0.0",
+        "info": {
+          "name": "System.Data.HashFunction.Interfaces",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "id": "System.ValueTuple@8.0.0",
+        "info": {
+          "name": "System.ValueTuple",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Diagnostics.EventLog@4.6.0",
+        "info": {
+          "name": "System.Diagnostics.EventLog",
+          "version": "4.6.0"
+        }
+      },
+      {
+        "id": "System.IdentityModel.Tokens.Jwt@6.35.0",
+        "info": {
+          "name": "System.IdentityModel.Tokens.Jwt",
+          "version": "6.35.0"
+        }
+      },
+      {
+        "id": "Microsoft.IdentityModel.JsonWebTokens@6.35.0",
+        "info": {
+          "name": "Microsoft.IdentityModel.JsonWebTokens",
+          "version": "6.35.0"
+        }
+      },
+      {
+        "id": "Microsoft.IdentityModel.Tokens@6.35.0",
+        "info": {
+          "name": "Microsoft.IdentityModel.Tokens",
+          "version": "6.35.0"
+        }
+      },
+      {
+        "id": "Microsoft.IdentityModel.Logging@6.35.0",
+        "info": {
+          "name": "Microsoft.IdentityModel.Logging",
+          "version": "6.35.0"
+        }
+      },
+      {
+        "id": "Microsoft.IdentityModel.Abstractions@6.35.0",
+        "info": {
+          "name": "Microsoft.IdentityModel.Abstractions",
+          "version": "6.35.0"
+        }
+      },
+      {
+        "id": "System.ServiceModel.Syndication@4.5.0",
+        "info": {
+          "name": "System.ServiceModel.Syndication",
+          "version": "4.5.0"
+        }
+      },
+      {
+        "id": "System.Threading.AccessControl@4.5.0",
+        "info": {
+          "name": "System.Threading.AccessControl",
+          "version": "4.5.0"
+        }
+      },
+      {
+        "id": "Ude.NetStandard@1.2.0",
+        "info": {
+          "name": "Ude.NetStandard",
+          "version": "1.2.0"
+        }
+      }
+    ],
+    "graph": {
+      "rootNodeId": "root-node",
+      "nodes": [
+        {
+          "nodeId": "root-node",
+          "pkgId": "dotnet_8_transitive_pinned_version@1.0.0",
+          "deps": [
+            {
+              "nodeId": "Aspire.RabbitMQ.Client@8.2.2"
+            },
+            {
+              "nodeId": "Dynamicweb.Security@12.5.21"
+            },
+            {
+              "nodeId": "Kentico.Xperience.Libraries@13.0.193"
+            },
+            {
+              "nodeId": "System.ServiceModel.Duplex@4.10.3"
+            },
+            {
+              "nodeId": "System.ServiceModel.Syndication@4.5.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Aspire.RabbitMQ.Client@8.2.2",
+          "pkgId": "Aspire.RabbitMQ.Client@8.2.2",
+          "deps": [
+            {
+              "nodeId": "AspNetCore.HealthChecks.Rabbitmq@8.0.2"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Binder@8.0.2"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Diagnostics.HealthChecks@8.0.10"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Hosting.Abstractions@8.0.1"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@8.0.0"
+            },
+            {
+              "nodeId": "OpenTelemetry.Extensions.Hosting@1.9.0"
+            },
+            {
+              "nodeId": "Polly.Core@8.4.2"
+            },
+            {
+              "nodeId": "RabbitMQ.Client@6.8.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "AspNetCore.HealthChecks.Rabbitmq@8.0.2",
+          "pkgId": "AspNetCore.HealthChecks.Rabbitmq@8.0.2",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Diagnostics.HealthChecks@8.0.10"
+            },
+            {
+              "nodeId": "RabbitMQ.Client@6.8.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Diagnostics.HealthChecks@8.0.10",
+          "pkgId": "Microsoft.Extensions.Diagnostics.HealthChecks@8.0.10",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions@8.0.10"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Hosting.Abstractions@8.0.1"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions@8.0.10",
+          "pkgId": "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions@8.0.10",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Hosting.Abstractions@8.0.1",
+          "pkgId": "Microsoft.Extensions.Hosting.Abstractions@8.0.1",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Diagnostics.Abstractions@8.0.1"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.FileProviders.Abstractions@8.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
+          "pkgId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@8.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Primitives@8.0.0",
+          "pkgId": "Microsoft.Extensions.Primitives@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2",
+          "pkgId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Diagnostics.Abstractions@8.0.1",
+          "pkgId": "Microsoft.Extensions.Diagnostics.Abstractions@8.0.1",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned",
+          "pkgId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Options@8.0.2",
+          "pkgId": "Microsoft.Extensions.Options@8.0.2",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@8.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.FileProviders.Abstractions@8.0.0",
+          "pkgId": "Microsoft.Extensions.FileProviders.Abstractions@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@8.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2",
+          "pkgId": "Microsoft.Extensions.Logging.Abstractions@8.0.2",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2"
+            }
+          ]
+        },
+        {
+          "nodeId": "RabbitMQ.Client@6.8.1",
+          "pkgId": "RabbitMQ.Client@6.8.1",
+          "deps": [
+            {
+              "nodeId": "System.Memory@4.5.5"
+            },
+            {
+              "nodeId": "System.Threading.Channels@7.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Memory@4.5.5",
+          "pkgId": "System.Memory@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Threading.Channels@7.0.0",
+          "pkgId": "System.Threading.Channels@7.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.Binder@8.0.2",
+          "pkgId": "Microsoft.Extensions.Configuration.Binder@8.0.2",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned",
+          "pkgId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "OpenTelemetry.Extensions.Hosting@1.9.0",
+          "pkgId": "OpenTelemetry.Extensions.Hosting@1.9.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Hosting.Abstractions@8.0.1:pruned"
+            },
+            {
+              "nodeId": "OpenTelemetry@1.9.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Hosting.Abstractions@8.0.1:pruned",
+          "pkgId": "Microsoft.Extensions.Hosting.Abstractions@8.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "OpenTelemetry@1.9.0",
+          "pkgId": "OpenTelemetry@1.9.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Diagnostics.Abstractions@8.0.1"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Configuration@8.0.0"
+            },
+            {
+              "nodeId": "OpenTelemetry.Api.ProviderBuilderExtensions@1.9.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Options@8.0.2:pruned",
+          "pkgId": "Microsoft.Extensions.Options@8.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Logging.Configuration@8.0.0",
+          "pkgId": "Microsoft.Extensions.Logging.Configuration@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration@8.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Binder@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging@8.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options.ConfigurationExtensions@8.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration@8.0.0",
+          "pkgId": "Microsoft.Extensions.Configuration@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@8.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@8.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Primitives@8.0.0:pruned",
+          "pkgId": "Microsoft.Extensions.Primitives@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.Binder@8.0.2:pruned",
+          "pkgId": "Microsoft.Extensions.Configuration.Binder@8.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Logging@8.0.0",
+          "pkgId": "Microsoft.Extensions.Logging@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection@8.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection@8.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.DependencyInjection@8.0.0",
+          "pkgId": "Microsoft.Extensions.DependencyInjection@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2:pruned",
+          "pkgId": "Microsoft.Extensions.Logging.Abstractions@8.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Options.ConfigurationExtensions@8.0.0",
+          "pkgId": "Microsoft.Extensions.Options.ConfigurationExtensions@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Binder@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@8.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@8.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "OpenTelemetry.Api.ProviderBuilderExtensions@1.9.0",
+          "pkgId": "OpenTelemetry.Api.ProviderBuilderExtensions@1.9.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2:pruned"
+            },
+            {
+              "nodeId": "OpenTelemetry.Api@1.9.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "OpenTelemetry.Api@1.9.0",
+          "pkgId": "OpenTelemetry.Api@1.9.0",
+          "deps": [
+            {
+              "nodeId": "System.Diagnostics.DiagnosticSource@8.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Diagnostics.DiagnosticSource@8.0.0",
+          "pkgId": "System.Diagnostics.DiagnosticSource@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Polly.Core@8.4.2",
+          "pkgId": "Polly.Core@8.4.2",
+          "deps": []
+        },
+        {
+          "nodeId": "Dynamicweb.Security@12.5.21",
+          "pkgId": "Dynamicweb.Security@12.5.21",
+          "deps": [
+            {
+              "nodeId": "Dynamicweb.Caching@3.1.2"
+            },
+            {
+              "nodeId": "Dynamicweb.Configuration@4.1.3"
+            },
+            {
+              "nodeId": "Dynamicweb.Core@4.1.1"
+            },
+            {
+              "nodeId": "Dynamicweb.Core.UI@3.0.1"
+            },
+            {
+              "nodeId": "Dynamicweb.Data@3.1.0"
+            },
+            {
+              "nodeId": "Dynamicweb.Environment@4.0.11"
+            },
+            {
+              "nodeId": "Dynamicweb.Extensibility@5.0.4"
+            },
+            {
+              "nodeId": "Dynamicweb.Logging@6.0.3"
+            },
+            {
+              "nodeId": "Dynamicweb.Mailing@5.0.6"
+            },
+            {
+              "nodeId": "Dynamicweb.Updates@1.1.0"
+            },
+            {
+              "nodeId": "System.DirectoryServices@5.0.0"
+            },
+            {
+              "nodeId": "System.Net.Http.Json@5.0.0"
+            },
+            {
+              "nodeId": "System.ServiceModel.Duplex@4.10.3"
+            },
+            {
+              "nodeId": "System.ServiceModel.Http@4.10.3"
+            },
+            {
+              "nodeId": "System.ServiceModel.NetTcp@4.10.3"
+            },
+            {
+              "nodeId": "System.ServiceModel.Security@4.10.3"
+            }
+          ]
+        },
+        {
+          "nodeId": "Dynamicweb.Caching@3.1.2",
+          "pkgId": "Dynamicweb.Caching@3.1.2",
+          "deps": [
+            {
+              "nodeId": "Dynamicweb.Core@4.1.1"
+            },
+            {
+              "nodeId": "Dynamicweb.Extensibility@5.0.4"
+            },
+            {
+              "nodeId": "System.Runtime.Caching@4.7.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Dynamicweb.Core@4.1.1",
+          "pkgId": "Dynamicweb.Core@4.1.1",
+          "deps": [
+            {
+              "nodeId": "Newtonsoft.Json@13.0.3"
+            },
+            {
+              "nodeId": "System.ComponentModel.Composition@4.7.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Newtonsoft.Json@13.0.3",
+          "pkgId": "Newtonsoft.Json@13.0.3",
+          "deps": []
+        },
+        {
+          "nodeId": "System.ComponentModel.Composition@4.7.0",
+          "pkgId": "System.ComponentModel.Composition@4.7.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Dynamicweb.Extensibility@5.0.4",
+          "pkgId": "Dynamicweb.Extensibility@5.0.4",
+          "deps": [
+            {
+              "nodeId": "Dynamicweb.Core@4.1.1:pruned"
+            },
+            {
+              "nodeId": "Dynamicweb.Core.UI@3.0.1"
+            },
+            {
+              "nodeId": "System.ComponentModel.Composition@4.7.0"
+            },
+            {
+              "nodeId": "System.Reflection.Emit@4.7.0"
+            },
+            {
+              "nodeId": "Dynamicweb.Core.UI@3.0.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Dynamicweb.Core@4.1.1:pruned",
+          "pkgId": "Dynamicweb.Core@4.1.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Dynamicweb.Core.UI@3.0.1",
+          "pkgId": "Dynamicweb.Core.UI@3.0.1",
+          "deps": [
+            {
+              "nodeId": "Newtonsoft.Json@13.0.3"
+            },
+            {
+              "nodeId": "System.ComponentModel.Composition@4.7.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.Emit@4.7.0",
+          "pkgId": "System.Reflection.Emit@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Runtime.Caching@4.7.0",
+          "pkgId": "System.Runtime.Caching@4.7.0",
+          "deps": [
+            {
+              "nodeId": "System.Configuration.ConfigurationManager@4.7.0"
+            },
+            {
+              "nodeId": "System.Configuration.ConfigurationManager@4.7.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Configuration.ConfigurationManager@4.7.0",
+          "pkgId": "System.Configuration.ConfigurationManager@4.7.0",
+          "deps": [
+            {
+              "nodeId": "System.Security.Cryptography.ProtectedData@4.7.0"
+            },
+            {
+              "nodeId": "System.Security.Permissions@5.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Security.Cryptography.ProtectedData@4.7.0",
+          "pkgId": "System.Security.Cryptography.ProtectedData@4.7.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Security.Permissions@5.0.0",
+          "pkgId": "System.Security.Permissions@5.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Security.AccessControl@6.0.0"
+            },
+            {
+              "nodeId": "System.Windows.Extensions@5.0.0"
+            },
+            {
+              "nodeId": "System.Security.AccessControl@6.0.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Security.AccessControl@6.0.0",
+          "pkgId": "System.Security.AccessControl@6.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Windows.Extensions@5.0.0",
+          "pkgId": "System.Windows.Extensions@5.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Drawing.Common@5.0.3"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Drawing.Common@5.0.3",
+          "pkgId": "System.Drawing.Common@5.0.3",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Win32.SystemEvents@5.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Win32.SystemEvents@5.0.0",
+          "pkgId": "Microsoft.Win32.SystemEvents@5.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.NETCore.Platforms@5.0.0",
+          "pkgId": "Microsoft.NETCore.Platforms@5.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Dynamicweb.Configuration@4.1.3",
+          "pkgId": "Dynamicweb.Configuration@4.1.3",
+          "deps": [
+            {
+              "nodeId": "Dynamicweb.Caching@3.1.2:pruned"
+            },
+            {
+              "nodeId": "Dynamicweb.Core@4.1.1"
+            },
+            {
+              "nodeId": "Dynamicweb.Extensibility@5.0.4"
+            }
+          ]
+        },
+        {
+          "nodeId": "Dynamicweb.Caching@3.1.2:pruned",
+          "pkgId": "Dynamicweb.Caching@3.1.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Dynamicweb.Data@3.1.0",
+          "pkgId": "Dynamicweb.Data@3.1.0",
+          "deps": [
+            {
+              "nodeId": "Dynamicweb.Caching@3.1.2:pruned"
+            },
+            {
+              "nodeId": "Dynamicweb.Configuration@4.1.3:pruned"
+            },
+            {
+              "nodeId": "Dynamicweb.Core@4.1.1:pruned"
+            },
+            {
+              "nodeId": "Dynamicweb.Diagnostics@4.0.3"
+            },
+            {
+              "nodeId": "Dynamicweb.Extensibility@5.0.4"
+            },
+            {
+              "nodeId": "Dynamicweb.Logging@6.0.3"
+            },
+            {
+              "nodeId": "EPPlus@5.6.3"
+            },
+            {
+              "nodeId": "System.Data.Common@4.3.0"
+            },
+            {
+              "nodeId": "System.Data.OleDb@4.7.1"
+            },
+            {
+              "nodeId": "System.Data.SqlClient@4.8.6"
+            }
+          ]
+        },
+        {
+          "nodeId": "Dynamicweb.Configuration@4.1.3:pruned",
+          "pkgId": "Dynamicweb.Configuration@4.1.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Dynamicweb.Diagnostics@4.0.3",
+          "pkgId": "Dynamicweb.Diagnostics@4.0.3",
+          "deps": [
+            {
+              "nodeId": "Dynamicweb.Core.UI@3.0.1:pruned"
+            },
+            {
+              "nodeId": "Dynamicweb.Extensibility@5.0.4"
+            },
+            {
+              "nodeId": "Dynamicweb.Logging@6.0.3"
+            }
+          ]
+        },
+        {
+          "nodeId": "Dynamicweb.Core.UI@3.0.1:pruned",
+          "pkgId": "Dynamicweb.Core.UI@3.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Dynamicweb.Logging@6.0.3",
+          "pkgId": "Dynamicweb.Logging@6.0.3",
+          "deps": [
+            {
+              "nodeId": "Dynamicweb.Caching@3.1.2:pruned"
+            },
+            {
+              "nodeId": "Dynamicweb.Core@4.1.1:pruned"
+            },
+            {
+              "nodeId": "Dynamicweb.Extensibility@5.0.4:pruned"
+            },
+            {
+              "nodeId": "NLog@4.5.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Dynamicweb.Extensibility@5.0.4:pruned",
+          "pkgId": "Dynamicweb.Extensibility@5.0.4",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "NLog@4.5.0",
+          "pkgId": "NLog@4.5.0",
+          "deps": []
+        },
+        {
+          "nodeId": "EPPlus@5.6.3",
+          "pkgId": "EPPlus@5.6.3",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Json@5.0.0"
+            },
+            {
+              "nodeId": "Microsoft.IO.RecyclableMemoryStream@1.4.1"
+            },
+            {
+              "nodeId": "System.ComponentModel.Annotations@5.0.0"
+            },
+            {
+              "nodeId": "System.ComponentModel.TypeConverter@4.3.0"
+            },
+            {
+              "nodeId": "System.Data.Common@4.3.0"
+            },
+            {
+              "nodeId": "System.Drawing.Common@5.0.3"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Claims@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Pkcs@8.0.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.X509Certificates@4.3.2"
+            },
+            {
+              "nodeId": "System.Text.Encoding.CodePages@6.0.0"
+            },
+            {
+              "nodeId": "System.Xml.XPath.XmlDocument@4.3.0"
+            },
+            {
+              "nodeId": "System.Xml.XmlDocument@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.Json@5.0.0",
+          "pkgId": "Microsoft.Extensions.Configuration.Json@5.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration@8.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.FileExtensions@5.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.FileProviders.Abstractions@8.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.FileExtensions@5.0.0",
+          "pkgId": "Microsoft.Extensions.Configuration.FileExtensions@5.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration@8.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@8.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.FileProviders.Abstractions@8.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.FileProviders.Physical@5.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@8.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration@8.0.0:pruned",
+          "pkgId": "Microsoft.Extensions.Configuration@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.FileProviders.Physical@5.0.0",
+          "pkgId": "Microsoft.Extensions.FileProviders.Physical@5.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.FileProviders.Abstractions@8.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.FileSystemGlobbing@5.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@8.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.FileProviders.Abstractions@8.0.0:pruned",
+          "pkgId": "Microsoft.Extensions.FileProviders.Abstractions@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.FileSystemGlobbing@5.0.0",
+          "pkgId": "Microsoft.Extensions.FileSystemGlobbing@5.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.IO.RecyclableMemoryStream@1.4.1",
+          "pkgId": "Microsoft.IO.RecyclableMemoryStream@1.4.1",
+          "deps": []
+        },
+        {
+          "nodeId": "System.ComponentModel.Annotations@5.0.0",
+          "pkgId": "System.ComponentModel.Annotations@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.ComponentModel.TypeConverter@4.3.0",
+          "pkgId": "System.ComponentModel.TypeConverter@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0"
+            },
+            {
+              "nodeId": "System.Collections.NonGeneric@4.3.0"
+            },
+            {
+              "nodeId": "System.Collections.Specialized@4.3.0"
+            },
+            {
+              "nodeId": "System.ComponentModel@4.3.0"
+            },
+            {
+              "nodeId": "System.ComponentModel.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0"
+            },
+            {
+              "nodeId": "System.Linq@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.TypeExtensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Collections@4.3.0",
+          "pkgId": "System.Collections@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.NETCore.Targets@1.1.0",
+          "pkgId": "Microsoft.NETCore.Targets@1.1.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Runtime@4.3.0",
+          "pkgId": "System.Runtime@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.NETCore.Platforms@5.0.0:pruned",
+          "pkgId": "Microsoft.NETCore.Platforms@5.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned",
+          "pkgId": "Microsoft.NETCore.Targets@1.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Collections.NonGeneric@4.3.0",
+          "pkgId": "System.Collections.NonGeneric@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Diagnostics.Debug@4.3.0",
+          "pkgId": "System.Diagnostics.Debug@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Globalization@4.3.0",
+          "pkgId": "System.Globalization@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Resources.ResourceManager@4.3.0",
+          "pkgId": "System.Resources.ResourceManager@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Globalization@4.3.0:pruned",
+          "pkgId": "System.Globalization@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Reflection@4.3.0",
+          "pkgId": "System.Reflection@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.IO@4.3.0",
+          "pkgId": "System.IO@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Text.Encoding@4.3.0",
+          "pkgId": "System.Text.Encoding@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Runtime@4.3.0:pruned",
+          "pkgId": "System.Runtime@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Threading.Tasks@4.3.0",
+          "pkgId": "System.Threading.Tasks@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.Primitives@4.3.0",
+          "pkgId": "System.Reflection.Primitives@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Runtime.Extensions@4.3.0",
+          "pkgId": "System.Runtime.Extensions@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Threading@4.3.0",
+          "pkgId": "System.Threading@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Collections.Specialized@4.3.0",
+          "pkgId": "System.Collections.Specialized@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections.NonGeneric@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0"
+            },
+            {
+              "nodeId": "System.Globalization.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Collections.NonGeneric@4.3.0:pruned",
+          "pkgId": "System.Collections.NonGeneric@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Globalization.Extensions@4.3.0",
+          "pkgId": "System.Globalization.Extensions@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Runtime.InteropServices@4.3.0",
+          "pkgId": "System.Runtime.InteropServices@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Runtime.Handles@4.3.0",
+          "pkgId": "System.Runtime.Handles@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.ComponentModel@4.3.0",
+          "pkgId": "System.ComponentModel@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.ComponentModel.Primitives@4.3.0",
+          "pkgId": "System.ComponentModel.Primitives@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.ComponentModel@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.ComponentModel@4.3.0:pruned",
+          "pkgId": "System.ComponentModel@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Linq@4.3.0",
+          "pkgId": "System.Linq@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Collections@4.3.0:pruned",
+          "pkgId": "System.Collections@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Reflection.Extensions@4.3.0",
+          "pkgId": "System.Reflection.Extensions@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection@4.3.0:pruned",
+          "pkgId": "System.Reflection@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Reflection.TypeExtensions@4.3.0",
+          "pkgId": "System.Reflection.TypeExtensions@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Data.Common@4.3.0",
+          "pkgId": "System.Data.Common@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0"
+            },
+            {
+              "nodeId": "System.IO@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.RegularExpressions@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.IO@4.3.0:pruned",
+          "pkgId": "System.IO@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Text.RegularExpressions@4.3.0",
+          "pkgId": "System.Text.RegularExpressions@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Security.Claims@4.3.0",
+          "pkgId": "System.Security.Claims@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0"
+            },
+            {
+              "nodeId": "System.IO@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Principal@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Security.Principal@4.3.0",
+          "pkgId": "System.Security.Principal@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Pkcs@8.0.0",
+          "pkgId": "System.Security.Cryptography.Pkcs@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Formats.Asn1@8.0.1"
+            },
+            {
+              "nodeId": "System.Formats.Asn1@8.0.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Formats.Asn1@8.0.1",
+          "pkgId": "System.Formats.Asn1@8.0.1",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Security.Cryptography.X509Certificates@4.3.2",
+          "pkgId": "System.Security.Cryptography.X509Certificates@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0"
+            },
+            {
+              "nodeId": "System.Globalization.Calendars@4.3.0"
+            },
+            {
+              "nodeId": "System.IO@4.3.0"
+            },
+            {
+              "nodeId": "System.IO.FileSystem@4.3.0"
+            },
+            {
+              "nodeId": "System.IO.FileSystem.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Numerics@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Algorithms@4.3.1"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Cng@5.0.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Csp@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.OpenSsl@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0:pruned"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.FileSystem@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Algorithms@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.OpenSsl@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Globalization.Calendars@4.3.0",
+          "pkgId": "System.Globalization.Calendars@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.IO.FileSystem@4.3.0",
+          "pkgId": "System.IO.FileSystem@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.FileSystem.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.IO.FileSystem.Primitives@4.3.0",
+          "pkgId": "System.IO.FileSystem.Primitives@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Runtime.Handles@4.3.0:pruned",
+          "pkgId": "System.Runtime.Handles@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Runtime.Numerics@4.3.0",
+          "pkgId": "System.Runtime.Numerics@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Resources.ResourceManager@4.3.0:pruned",
+          "pkgId": "System.Resources.ResourceManager@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Runtime.Extensions@4.3.0:pruned",
+          "pkgId": "System.Runtime.Extensions@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Algorithms@4.3.1",
+          "pkgId": "System.Security.Cryptography.Algorithms@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0:pruned"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Numerics@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Numerics@4.3.0"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0"
+            },
+            {
+              "nodeId": "System.IO@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Runtime.InteropServices@4.3.0:pruned",
+          "pkgId": "System.Runtime.InteropServices@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Runtime.Numerics@4.3.0:pruned",
+          "pkgId": "System.Runtime.Numerics@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Encoding@4.3.0",
+          "pkgId": "System.Security.Cryptography.Encoding@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0:pruned"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Collections.Concurrent@4.3.0"
+            },
+            {
+              "nodeId": "System.Linq@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Collections.Concurrent@4.3.0",
+          "pkgId": "System.Collections.Concurrent@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Tracing@4.3.0"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.Tracing@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Diagnostics.Debug@4.3.0:pruned",
+          "pkgId": "System.Diagnostics.Debug@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Diagnostics.Tracing@4.3.0",
+          "pkgId": "System.Diagnostics.Tracing@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Primitives@4.3.0",
+          "pkgId": "System.Security.Cryptography.Primitives@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Cng@5.0.0",
+          "pkgId": "System.Security.Cryptography.Cng@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Formats.Asn1@8.0.1"
+            },
+            {
+              "nodeId": "System.Formats.Asn1@8.0.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Csp@4.3.0",
+          "pkgId": "System.Security.Cryptography.Csp@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Algorithms@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0"
+            },
+            {
+              "nodeId": "System.IO@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Algorithms@4.3.1:pruned",
+          "pkgId": "System.Security.Cryptography.Algorithms@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Security.Cryptography.OpenSsl@4.3.0",
+          "pkgId": "System.Security.Cryptography.OpenSsl@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Numerics@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Algorithms@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Numerics@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Encoding@4.3.0:pruned",
+          "pkgId": "System.Security.Cryptography.Encoding@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Text.Encoding.CodePages@6.0.0",
+          "pkgId": "System.Text.Encoding.CodePages@6.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Runtime.CompilerServices.Unsafe@6.0.0"
+            },
+            {
+              "nodeId": "System.Runtime.CompilerServices.Unsafe@6.0.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Runtime.CompilerServices.Unsafe@6.0.0",
+          "pkgId": "System.Runtime.CompilerServices.Unsafe@6.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Xml.XPath.XmlDocument@4.3.0",
+          "pkgId": "System.Xml.XPath.XmlDocument@4.3.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0"
+            },
+            {
+              "nodeId": "System.IO@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0"
+            },
+            {
+              "nodeId": "System.Xml.ReaderWriter@4.3.0"
+            },
+            {
+              "nodeId": "System.Xml.XPath@4.3.0"
+            },
+            {
+              "nodeId": "System.Xml.XmlDocument@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Xml.ReaderWriter@4.3.0",
+          "pkgId": "System.Xml.ReaderWriter@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.FileSystem@4.3.0"
+            },
+            {
+              "nodeId": "System.IO.FileSystem.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.Encoding.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.RegularExpressions@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading.Tasks.Extensions@4.5.4"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Text.Encoding.Extensions@4.3.0",
+          "pkgId": "System.Text.Encoding.Extensions@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Text.Encoding@4.3.0:pruned",
+          "pkgId": "System.Text.Encoding@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Threading.Tasks.Extensions@4.5.4",
+          "pkgId": "System.Threading.Tasks.Extensions@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Xml.XPath@4.3.0",
+          "pkgId": "System.Xml.XPath@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Xml.ReaderWriter@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Threading@4.3.0:pruned",
+          "pkgId": "System.Threading@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Xml.ReaderWriter@4.3.0:pruned",
+          "pkgId": "System.Xml.ReaderWriter@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Xml.XmlDocument@4.3.0",
+          "pkgId": "System.Xml.XmlDocument@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Xml.ReaderWriter@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0"
+            },
+            {
+              "nodeId": "System.IO@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0"
+            },
+            {
+              "nodeId": "System.Xml.ReaderWriter@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Data.OleDb@4.7.1",
+          "pkgId": "System.Data.OleDb@4.7.1",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Win32.Registry@4.7.0"
+            },
+            {
+              "nodeId": "System.Configuration.ConfigurationManager@4.7.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.PerformanceCounter@4.7.0"
+            },
+            {
+              "nodeId": "System.Security.Principal.Windows@5.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Win32.Registry@4.7.0",
+          "pkgId": "Microsoft.Win32.Registry@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Security.AccessControl@6.0.0"
+            },
+            {
+              "nodeId": "System.Security.Principal.Windows@5.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Security.Principal.Windows@5.0.0",
+          "pkgId": "System.Security.Principal.Windows@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Diagnostics.PerformanceCounter@4.7.0",
+          "pkgId": "System.Diagnostics.PerformanceCounter@4.7.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Win32.Registry@4.7.0:pruned"
+            },
+            {
+              "nodeId": "System.Configuration.ConfigurationManager@4.7.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Principal.Windows@5.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Win32.Registry@4.7.0:pruned",
+          "pkgId": "Microsoft.Win32.Registry@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Configuration.ConfigurationManager@4.7.0:pruned",
+          "pkgId": "System.Configuration.ConfigurationManager@4.7.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Data.SqlClient@4.8.6",
+          "pkgId": "System.Data.SqlClient@4.8.6",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Win32.Registry@4.7.0"
+            },
+            {
+              "nodeId": "System.Security.Principal.Windows@5.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Dynamicweb.Environment@4.0.11",
+          "pkgId": "Dynamicweb.Environment@4.0.11",
+          "deps": [
+            {
+              "nodeId": "Dynamicweb.Configuration@4.1.3:pruned"
+            },
+            {
+              "nodeId": "Dynamicweb.Core@4.1.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Dynamicweb.Mailing@5.0.6",
+          "pkgId": "Dynamicweb.Mailing@5.0.6",
+          "deps": [
+            {
+              "nodeId": "Dynamicweb.Data@3.1.0:pruned"
+            },
+            {
+              "nodeId": "Dynamicweb.Environment@4.0.11:pruned"
+            },
+            {
+              "nodeId": "Dynamicweb.Logging@6.0.3:pruned"
+            },
+            {
+              "nodeId": "Dynamicweb.Updates@1.1.0"
+            },
+            {
+              "nodeId": "HtmlAgilityPack@1.11.28"
+            }
+          ]
+        },
+        {
+          "nodeId": "Dynamicweb.Data@3.1.0:pruned",
+          "pkgId": "Dynamicweb.Data@3.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Dynamicweb.Environment@4.0.11:pruned",
+          "pkgId": "Dynamicweb.Environment@4.0.11",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Dynamicweb.Logging@6.0.3:pruned",
+          "pkgId": "Dynamicweb.Logging@6.0.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Dynamicweb.Updates@1.1.0",
+          "pkgId": "Dynamicweb.Updates@1.1.0",
+          "deps": [
+            {
+              "nodeId": "Dynamicweb.Data@3.1.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "HtmlAgilityPack@1.11.28",
+          "pkgId": "HtmlAgilityPack@1.11.28",
+          "deps": []
+        },
+        {
+          "nodeId": "System.DirectoryServices@5.0.0",
+          "pkgId": "System.DirectoryServices@5.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0"
+            },
+            {
+              "nodeId": "System.IO.FileSystem.AccessControl@5.0.0"
+            },
+            {
+              "nodeId": "System.Security.AccessControl@6.0.0"
+            },
+            {
+              "nodeId": "System.Security.Permissions@5.0.0"
+            },
+            {
+              "nodeId": "System.Security.Principal.Windows@5.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.IO.FileSystem.AccessControl@5.0.0",
+          "pkgId": "System.IO.FileSystem.AccessControl@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Security.AccessControl@6.0.0"
+            },
+            {
+              "nodeId": "System.Security.Principal.Windows@5.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Security.AccessControl@6.0.0:pruned",
+          "pkgId": "System.Security.AccessControl@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Net.Http.Json@5.0.0",
+          "pkgId": "System.Net.Http.Json@5.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.ServiceModel.Duplex@4.10.3",
+          "pkgId": "System.ServiceModel.Duplex@4.10.3",
+          "deps": [
+            {
+              "nodeId": "System.Private.ServiceModel@4.10.3"
+            },
+            {
+              "nodeId": "System.ServiceModel.Primitives@4.10.3"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Private.ServiceModel@4.10.3",
+          "pkgId": "System.Private.ServiceModel@4.10.3",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Bcl.AsyncInterfaces@5.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.ObjectPool@5.0.10"
+            },
+            {
+              "nodeId": "System.Numerics.Vectors@4.5.0"
+            },
+            {
+              "nodeId": "System.Reflection.DispatchProxy@4.7.1"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Xml@6.0.1"
+            },
+            {
+              "nodeId": "System.Security.Principal.Windows@5.0.0"
+            },
+            {
+              "nodeId": "System.Security.Principal.Windows@5.0.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Bcl.AsyncInterfaces@5.0.0",
+          "pkgId": "Microsoft.Bcl.AsyncInterfaces@5.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Extensions.ObjectPool@5.0.10",
+          "pkgId": "Microsoft.Extensions.ObjectPool@5.0.10",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Numerics.Vectors@4.5.0",
+          "pkgId": "System.Numerics.Vectors@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Reflection.DispatchProxy@4.7.1",
+          "pkgId": "System.Reflection.DispatchProxy@4.7.1",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Xml@6.0.1",
+          "pkgId": "System.Security.Cryptography.Xml@6.0.1",
+          "deps": [
+            {
+              "nodeId": "System.Security.AccessControl@6.0.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Pkcs@8.0.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Pkcs@8.0.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.ServiceModel.Primitives@4.10.3",
+          "pkgId": "System.ServiceModel.Primitives@4.10.3",
+          "deps": [
+            {
+              "nodeId": "System.Private.ServiceModel@4.10.3:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Private.ServiceModel@4.10.3:pruned",
+          "pkgId": "System.Private.ServiceModel@4.10.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.ServiceModel.Http@4.10.3",
+          "pkgId": "System.ServiceModel.Http@4.10.3",
+          "deps": [
+            {
+              "nodeId": "System.Private.ServiceModel@4.10.3"
+            },
+            {
+              "nodeId": "System.ServiceModel.Primitives@4.10.3"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.ServiceModel.NetTcp@4.10.3",
+          "pkgId": "System.ServiceModel.NetTcp@4.10.3",
+          "deps": [
+            {
+              "nodeId": "System.Private.ServiceModel@4.10.3"
+            },
+            {
+              "nodeId": "System.ServiceModel.Primitives@4.10.3"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.ServiceModel.Security@4.10.3",
+          "pkgId": "System.ServiceModel.Security@4.10.3",
+          "deps": [
+            {
+              "nodeId": "System.Private.ServiceModel@4.10.3"
+            },
+            {
+              "nodeId": "System.ServiceModel.Primitives@4.10.3"
+            }
+          ]
+        },
+        {
+          "nodeId": "Kentico.Xperience.Libraries@13.0.193",
+          "pkgId": "Kentico.Xperience.Libraries@13.0.193",
+          "deps": [
+            {
+              "nodeId": "AWSSDK.Core@3.5.1.13"
+            },
+            {
+              "nodeId": "AWSSDK.S3@3.5.1.4"
+            },
+            {
+              "nodeId": "AngleSharp@0.17.1"
+            },
+            {
+              "nodeId": "Azure.AI.TextAnalytics@5.2.0"
+            },
+            {
+              "nodeId": "DocumentFormat.OpenXml@2.19.0"
+            },
+            {
+              "nodeId": "MailKit@4.7.1.1"
+            },
+            {
+              "nodeId": "MaxMind.GeoIP2@3.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Azure.CognitiveServices.Vision.ComputerVision@7.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Azure.Search@10.1.0"
+            },
+            {
+              "nodeId": "Microsoft.Azure.Search.Service@10.1.0"
+            },
+            {
+              "nodeId": "Microsoft.Azure.Storage.Blob@11.2.2"
+            },
+            {
+              "nodeId": "Microsoft.Azure.Storage.Queue@11.2.2"
+            },
+            {
+              "nodeId": "Microsoft.CSharp@4.7.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Caching.Memory@3.1.8"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration@8.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Binder@8.0.2"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection@8.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.FileProviders.Abstractions@8.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.FileProviders.Physical@5.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Debug@3.1.8"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options.ConfigurationExtensions@8.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@8.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Rest.ClientRuntime@2.3.24"
+            },
+            {
+              "nodeId": "Microsoft.SqlServer.DacFx@150.4573.2"
+            },
+            {
+              "nodeId": "Mono.Cecil@0.10.0"
+            },
+            {
+              "nodeId": "Newtonsoft.Json@13.0.3"
+            },
+            {
+              "nodeId": "NuGet.Packaging@5.11.6"
+            },
+            {
+              "nodeId": "PreMailer.Net@2.2.0"
+            },
+            {
+              "nodeId": "System.CodeDom@4.5.0"
+            },
+            {
+              "nodeId": "System.Configuration.ConfigurationManager@4.7.0"
+            },
+            {
+              "nodeId": "System.Data.DataSetExtensions@4.5.0"
+            },
+            {
+              "nodeId": "System.Data.HashFunction.CRC@2.0.0"
+            },
+            {
+              "nodeId": "System.Data.SqlClient@4.8.6"
+            },
+            {
+              "nodeId": "System.Diagnostics.EventLog@4.6.0"
+            },
+            {
+              "nodeId": "System.Drawing.Common@5.0.3"
+            },
+            {
+              "nodeId": "System.Formats.Asn1@8.0.1"
+            },
+            {
+              "nodeId": "System.IO.FileSystem.AccessControl@5.0.0"
+            },
+            {
+              "nodeId": "System.IdentityModel.Tokens.Jwt@6.35.0"
+            },
+            {
+              "nodeId": "System.Memory@4.5.5"
+            },
+            {
+              "nodeId": "System.Runtime.Caching@4.7.0"
+            },
+            {
+              "nodeId": "System.Runtime.CompilerServices.Unsafe@6.0.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Pkcs@8.0.0"
+            },
+            {
+              "nodeId": "System.Security.Principal.Windows@5.0.0"
+            },
+            {
+              "nodeId": "System.ServiceModel.Duplex@4.10.3"
+            },
+            {
+              "nodeId": "System.ServiceModel.Http@4.10.3"
+            },
+            {
+              "nodeId": "System.ServiceModel.NetTcp@4.10.3"
+            },
+            {
+              "nodeId": "System.ServiceModel.Security@4.10.3"
+            },
+            {
+              "nodeId": "System.ServiceModel.Syndication@4.5.0"
+            },
+            {
+              "nodeId": "System.Text.Encoding.CodePages@6.0.0"
+            },
+            {
+              "nodeId": "System.Threading.AccessControl@4.5.0"
+            },
+            {
+              "nodeId": "Ude.NetStandard@1.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "AWSSDK.Core@3.5.1.13",
+          "pkgId": "AWSSDK.Core@3.5.1.13",
+          "deps": []
+        },
+        {
+          "nodeId": "AWSSDK.S3@3.5.1.4",
+          "pkgId": "AWSSDK.S3@3.5.1.4",
+          "deps": [
+            {
+              "nodeId": "AWSSDK.Core@3.5.1.13:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "AWSSDK.Core@3.5.1.13:pruned",
+          "pkgId": "AWSSDK.Core@3.5.1.13",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "AngleSharp@0.17.1",
+          "pkgId": "AngleSharp@0.17.1",
+          "deps": [
+            {
+              "nodeId": "System.Buffers@4.5.1"
+            },
+            {
+              "nodeId": "System.Text.Encoding.CodePages@6.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Buffers@4.5.1",
+          "pkgId": "System.Buffers@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Azure.AI.TextAnalytics@5.2.0",
+          "pkgId": "Azure.AI.TextAnalytics@5.2.0",
+          "deps": [
+            {
+              "nodeId": "Azure.Core@1.25.0"
+            },
+            {
+              "nodeId": "Microsoft.Bcl.AsyncInterfaces@5.0.0"
+            },
+            {
+              "nodeId": "System.Text.Json@4.7.2"
+            }
+          ]
+        },
+        {
+          "nodeId": "Azure.Core@1.25.0",
+          "pkgId": "Azure.Core@1.25.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Bcl.AsyncInterfaces@5.0.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.DiagnosticSource@8.0.0"
+            },
+            {
+              "nodeId": "System.Memory.Data@1.0.2"
+            },
+            {
+              "nodeId": "System.Numerics.Vectors@4.5.0"
+            },
+            {
+              "nodeId": "System.Text.Encodings.Web@4.7.2"
+            },
+            {
+              "nodeId": "System.Text.Json@4.7.2"
+            },
+            {
+              "nodeId": "System.Threading.Tasks.Extensions@4.5.4"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Memory.Data@1.0.2",
+          "pkgId": "System.Memory.Data@1.0.2",
+          "deps": [
+            {
+              "nodeId": "System.Text.Encodings.Web@4.7.2"
+            },
+            {
+              "nodeId": "System.Text.Json@4.7.2"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Text.Encodings.Web@4.7.2",
+          "pkgId": "System.Text.Encodings.Web@4.7.2",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Text.Json@4.7.2",
+          "pkgId": "System.Text.Json@4.7.2",
+          "deps": []
+        },
+        {
+          "nodeId": "DocumentFormat.OpenXml@2.19.0",
+          "pkgId": "DocumentFormat.OpenXml@2.19.0",
+          "deps": [
+            {
+              "nodeId": "System.IO.Packaging@4.7.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.IO.Packaging@4.7.0",
+          "pkgId": "System.IO.Packaging@4.7.0",
+          "deps": []
+        },
+        {
+          "nodeId": "MailKit@4.7.1.1",
+          "pkgId": "MailKit@4.7.1.1",
+          "deps": [
+            {
+              "nodeId": "MimeKit@4.7.1"
+            },
+            {
+              "nodeId": "System.Formats.Asn1@8.0.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "MimeKit@4.7.1",
+          "pkgId": "MimeKit@4.7.1",
+          "deps": [
+            {
+              "nodeId": "BouncyCastle.Cryptography@2.4.0"
+            },
+            {
+              "nodeId": "System.Formats.Asn1@8.0.1"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Pkcs@8.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "BouncyCastle.Cryptography@2.4.0",
+          "pkgId": "BouncyCastle.Cryptography@2.4.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Formats.Asn1@8.0.1:pruned",
+          "pkgId": "System.Formats.Asn1@8.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "MaxMind.GeoIP2@3.2.0",
+          "pkgId": "MaxMind.GeoIP2@3.2.0",
+          "deps": [
+            {
+              "nodeId": "MaxMind.Db@2.6.1"
+            },
+            {
+              "nodeId": "Microsoft.CSharp@4.7.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2"
+            },
+            {
+              "nodeId": "Newtonsoft.Json@13.0.3"
+            }
+          ]
+        },
+        {
+          "nodeId": "MaxMind.Db@2.6.1",
+          "pkgId": "MaxMind.Db@2.6.1",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.CSharp@4.7.0",
+          "pkgId": "Microsoft.CSharp@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Azure.CognitiveServices.Vision.ComputerVision@7.0.0",
+          "pkgId": "Microsoft.Azure.CognitiveServices.Vision.ComputerVision@7.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Rest.ClientRuntime@2.3.24"
+            },
+            {
+              "nodeId": "Microsoft.Rest.ClientRuntime.Azure@3.3.18"
+            },
+            {
+              "nodeId": "Newtonsoft.Json@13.0.3"
+            },
+            {
+              "nodeId": "System.Net.Http@4.3.4"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Rest.ClientRuntime@2.3.24",
+          "pkgId": "Microsoft.Rest.ClientRuntime@2.3.24",
+          "deps": [
+            {
+              "nodeId": "Newtonsoft.Json@13.0.3"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Rest.ClientRuntime.Azure@3.3.18",
+          "pkgId": "Microsoft.Rest.ClientRuntime.Azure@3.3.18",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Rest.ClientRuntime@2.3.24:pruned"
+            },
+            {
+              "nodeId": "NETStandard.Library@2.0.1"
+            },
+            {
+              "nodeId": "Newtonsoft.Json@13.0.3"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Rest.ClientRuntime@2.3.24:pruned",
+          "pkgId": "Microsoft.Rest.ClientRuntime@2.3.24",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "NETStandard.Library@2.0.1",
+          "pkgId": "NETStandard.Library@2.0.1",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Net.Http@4.3.4",
+          "pkgId": "System.Net.Http@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.DiagnosticSource@8.0.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.Tracing@4.3.0"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0"
+            },
+            {
+              "nodeId": "System.Globalization.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.IO@4.3.0"
+            },
+            {
+              "nodeId": "System.IO.FileSystem@4.3.0"
+            },
+            {
+              "nodeId": "System.Net.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Algorithms@4.3.1"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.OpenSsl@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.X509Certificates@4.3.2"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Net.Primitives@4.3.0",
+          "pkgId": "System.Net.Primitives@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Diagnostics.Tracing@4.3.0:pruned",
+          "pkgId": "System.Diagnostics.Tracing@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.IO.FileSystem@4.3.0:pruned",
+          "pkgId": "System.IO.FileSystem@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned",
+          "pkgId": "System.Security.Cryptography.Primitives@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Security.Cryptography.OpenSsl@4.3.0:pruned",
+          "pkgId": "System.Security.Cryptography.OpenSsl@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Azure.Search@10.1.0",
+          "pkgId": "Microsoft.Azure.Search@10.1.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Azure.Search.Data@10.1.0"
+            },
+            {
+              "nodeId": "Microsoft.Azure.Search.Service@10.1.0"
+            },
+            {
+              "nodeId": "Microsoft.Rest.ClientRuntime@2.3.24"
+            },
+            {
+              "nodeId": "Microsoft.Rest.ClientRuntime.Azure@3.3.18"
+            },
+            {
+              "nodeId": "Newtonsoft.Json@13.0.3"
+            },
+            {
+              "nodeId": "System.Net.Http@4.3.4"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Azure.Search.Data@10.1.0",
+          "pkgId": "Microsoft.Azure.Search.Data@10.1.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Azure.Search.Common@10.1.0"
+            },
+            {
+              "nodeId": "Microsoft.Rest.ClientRuntime@2.3.24"
+            },
+            {
+              "nodeId": "Microsoft.Rest.ClientRuntime.Azure@3.3.18"
+            },
+            {
+              "nodeId": "Microsoft.Spatial@7.5.3"
+            },
+            {
+              "nodeId": "Newtonsoft.Json@13.0.3"
+            },
+            {
+              "nodeId": "System.Net.Http@4.3.4"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Azure.Search.Common@10.1.0",
+          "pkgId": "Microsoft.Azure.Search.Common@10.1.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Rest.ClientRuntime@2.3.24"
+            },
+            {
+              "nodeId": "Microsoft.Rest.ClientRuntime.Azure@3.3.18"
+            },
+            {
+              "nodeId": "Newtonsoft.Json@13.0.3"
+            },
+            {
+              "nodeId": "System.Net.Http@4.3.4"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Spatial@7.5.3",
+          "pkgId": "Microsoft.Spatial@7.5.3",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Azure.Search.Service@10.1.0",
+          "pkgId": "Microsoft.Azure.Search.Service@10.1.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Azure.Search.Common@10.1.0"
+            },
+            {
+              "nodeId": "Microsoft.Rest.ClientRuntime@2.3.24"
+            },
+            {
+              "nodeId": "Microsoft.Rest.ClientRuntime.Azure@3.3.18"
+            },
+            {
+              "nodeId": "Microsoft.Spatial@7.5.3"
+            },
+            {
+              "nodeId": "Newtonsoft.Json@13.0.3"
+            },
+            {
+              "nodeId": "System.Net.Http@4.3.4"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Azure.Storage.Blob@11.2.2",
+          "pkgId": "Microsoft.Azure.Storage.Blob@11.2.2",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Azure.Storage.Common@11.2.2"
+            },
+            {
+              "nodeId": "NETStandard.Library@2.0.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Azure.Storage.Common@11.2.2",
+          "pkgId": "Microsoft.Azure.Storage.Common@11.2.2",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Azure.KeyVault.Core@2.0.4"
+            },
+            {
+              "nodeId": "NETStandard.Library@2.0.1"
+            },
+            {
+              "nodeId": "Newtonsoft.Json@13.0.3"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Azure.KeyVault.Core@2.0.4",
+          "pkgId": "Microsoft.Azure.KeyVault.Core@2.0.4",
+          "deps": [
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Azure.Storage.Queue@11.2.2",
+          "pkgId": "Microsoft.Azure.Storage.Queue@11.2.2",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Azure.Storage.Common@11.2.2"
+            },
+            {
+              "nodeId": "NETStandard.Library@2.0.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Caching.Memory@3.1.8",
+          "pkgId": "Microsoft.Extensions.Caching.Memory@3.1.8",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Caching.Abstractions@3.1.8"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@8.0.2"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@8.0.2"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@8.0.2"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Caching.Abstractions@3.1.8",
+          "pkgId": "Microsoft.Extensions.Caching.Abstractions@3.1.8",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@8.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Logging.Debug@3.1.8",
+          "pkgId": "Microsoft.Extensions.Logging.Debug@3.1.8",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Logging@8.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.DependencyInjection@8.0.0:pruned",
+          "pkgId": "Microsoft.Extensions.DependencyInjection@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.SqlServer.DacFx@150.4573.2",
+          "pkgId": "Microsoft.SqlServer.DacFx@150.4573.2",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Build@15.9.20"
+            },
+            {
+              "nodeId": "Microsoft.Build.Framework@15.9.20"
+            },
+            {
+              "nodeId": "System.ComponentModel.Composition@4.7.0"
+            },
+            {
+              "nodeId": "System.Data.SqlClient@4.8.6"
+            },
+            {
+              "nodeId": "System.IO.FileSystem@4.3.0"
+            },
+            {
+              "nodeId": "System.IO.FileSystem.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Net.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Algorithms@4.3.1"
+            },
+            {
+              "nodeId": "System.Security.Permissions@5.0.0"
+            },
+            {
+              "nodeId": "System.Security.Principal@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.Encoding.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading.ThreadPool@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Build@15.9.20",
+          "pkgId": "Microsoft.Build@15.9.20",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Build.Framework@15.9.20"
+            },
+            {
+              "nodeId": "Microsoft.Win32.Registry@4.7.0"
+            },
+            {
+              "nodeId": "System.Collections.Immutable@1.5.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.TraceSource@4.0.0"
+            },
+            {
+              "nodeId": "System.IO.Compression@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.Metadata@1.6.0"
+            },
+            {
+              "nodeId": "System.Reflection.TypeExtensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices.RuntimeInformation@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Loader@4.0.0"
+            },
+            {
+              "nodeId": "System.Security.Principal.Windows@5.0.0"
+            },
+            {
+              "nodeId": "System.Text.Encoding.CodePages@6.0.0"
+            },
+            {
+              "nodeId": "System.Threading.Tasks.Dataflow@4.6.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Build.Framework@15.9.20",
+          "pkgId": "Microsoft.Build.Framework@15.9.20",
+          "deps": [
+            {
+              "nodeId": "System.Runtime.Serialization.Primitives@4.1.1"
+            },
+            {
+              "nodeId": "System.Threading.Thread@4.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Runtime.Serialization.Primitives@4.1.1",
+          "pkgId": "System.Runtime.Serialization.Primitives@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Threading.Thread@4.0.0",
+          "pkgId": "System.Threading.Thread@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Collections.Immutable@1.5.0",
+          "pkgId": "System.Collections.Immutable@1.5.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Diagnostics.TraceSource@4.0.0",
+          "pkgId": "System.Diagnostics.TraceSource@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.IO.Compression@4.3.0",
+          "pkgId": "System.IO.Compression@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0"
+            },
+            {
+              "nodeId": "System.Buffers@4.5.1"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0"
+            },
+            {
+              "nodeId": "System.IO@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.Metadata@1.6.0",
+          "pkgId": "System.Reflection.Metadata@1.6.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Runtime.InteropServices.RuntimeInformation@4.3.0",
+          "pkgId": "System.Runtime.InteropServices.RuntimeInformation@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Reflection@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Runtime.Loader@4.0.0",
+          "pkgId": "System.Runtime.Loader@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.IO@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Threading.Tasks.Dataflow@4.6.0",
+          "pkgId": "System.Threading.Tasks.Dataflow@4.6.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0"
+            },
+            {
+              "nodeId": "System.Collections.Concurrent@4.3.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.Tracing@4.3.0"
+            },
+            {
+              "nodeId": "System.Dynamic.Runtime@4.0.11"
+            },
+            {
+              "nodeId": "System.Linq@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Dynamic.Runtime@4.0.11",
+          "pkgId": "System.Dynamic.Runtime@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0"
+            },
+            {
+              "nodeId": "System.Linq@4.3.0"
+            },
+            {
+              "nodeId": "System.Linq.Expressions@4.1.0"
+            },
+            {
+              "nodeId": "System.ObjectModel@4.0.12"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.Emit@4.7.0"
+            },
+            {
+              "nodeId": "System.Reflection.Emit.ILGeneration@4.0.1"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.TypeExtensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Linq.Expressions@4.1.0",
+          "pkgId": "System.Linq.Expressions@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0"
+            },
+            {
+              "nodeId": "System.Linq@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.ObjectModel@4.0.12"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.Emit@4.7.0"
+            },
+            {
+              "nodeId": "System.Reflection.Emit.ILGeneration@4.0.1"
+            },
+            {
+              "nodeId": "System.Reflection.Emit.Lightweight@4.0.1"
+            },
+            {
+              "nodeId": "System.Reflection.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.TypeExtensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Linq@4.3.0:pruned",
+          "pkgId": "System.Linq@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.ObjectModel@4.0.12",
+          "pkgId": "System.ObjectModel@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.Emit.ILGeneration@4.0.1",
+          "pkgId": "System.Reflection.Emit.ILGeneration@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.Emit.Lightweight@4.0.1",
+          "pkgId": "System.Reflection.Emit.Lightweight@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Emit.ILGeneration@4.0.1:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.Emit.ILGeneration@4.0.1:pruned",
+          "pkgId": "System.Reflection.Emit.ILGeneration@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Reflection.TypeExtensions@4.3.0:pruned",
+          "pkgId": "System.Reflection.TypeExtensions@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Threading.ThreadPool@4.3.0",
+          "pkgId": "System.Threading.ThreadPool@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Runtime@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Mono.Cecil@0.10.0",
+          "pkgId": "Mono.Cecil@0.10.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0"
+            },
+            {
+              "nodeId": "System.IO.FileSystem@4.3.0"
+            },
+            {
+              "nodeId": "System.IO.FileSystem.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Algorithms@4.3.1"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Csp@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "NuGet.Packaging@5.11.6",
+          "pkgId": "NuGet.Packaging@5.11.6",
+          "deps": [
+            {
+              "nodeId": "Newtonsoft.Json@13.0.3:pruned"
+            },
+            {
+              "nodeId": "NuGet.Configuration@5.11.6"
+            },
+            {
+              "nodeId": "NuGet.Versioning@5.11.6"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Cng@5.0.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Pkcs@8.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Newtonsoft.Json@13.0.3:pruned",
+          "pkgId": "Newtonsoft.Json@13.0.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "NuGet.Configuration@5.11.6",
+          "pkgId": "NuGet.Configuration@5.11.6",
+          "deps": [
+            {
+              "nodeId": "NuGet.Common@5.11.6"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.ProtectedData@4.7.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "NuGet.Common@5.11.6",
+          "pkgId": "NuGet.Common@5.11.6",
+          "deps": [
+            {
+              "nodeId": "NuGet.Frameworks@5.11.6"
+            }
+          ]
+        },
+        {
+          "nodeId": "NuGet.Frameworks@5.11.6",
+          "pkgId": "NuGet.Frameworks@5.11.6",
+          "deps": []
+        },
+        {
+          "nodeId": "NuGet.Versioning@5.11.6",
+          "pkgId": "NuGet.Versioning@5.11.6",
+          "deps": []
+        },
+        {
+          "nodeId": "PreMailer.Net@2.2.0",
+          "pkgId": "PreMailer.Net@2.2.0",
+          "deps": [
+            {
+              "nodeId": "AngleSharp@0.17.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "AngleSharp@0.17.1:pruned",
+          "pkgId": "AngleSharp@0.17.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.CodeDom@4.5.0",
+          "pkgId": "System.CodeDom@4.5.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Data.DataSetExtensions@4.5.0",
+          "pkgId": "System.Data.DataSetExtensions@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Data.HashFunction.CRC@2.0.0",
+          "pkgId": "System.Data.HashFunction.CRC@2.0.0",
+          "deps": [
+            {
+              "nodeId": "NETStandard.Library@2.0.1"
+            },
+            {
+              "nodeId": "System.Data.HashFunction.Core@2.0.0"
+            },
+            {
+              "nodeId": "System.ValueTuple@4.4.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Data.HashFunction.Core@2.0.0",
+          "pkgId": "System.Data.HashFunction.Core@2.0.0",
+          "deps": [
+            {
+              "nodeId": "NETStandard.Library@2.0.1:pruned"
+            },
+            {
+              "nodeId": "System.Data.HashFunction.Interfaces@2.0.0"
+            },
+            {
+              "nodeId": "System.Runtime.Numerics@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "NETStandard.Library@2.0.1:pruned",
+          "pkgId": "NETStandard.Library@2.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Data.HashFunction.Interfaces@2.0.0",
+          "pkgId": "System.Data.HashFunction.Interfaces@2.0.0",
+          "deps": [
+            {
+              "nodeId": "NETStandard.Library@2.0.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.ValueTuple@4.4.0",
+          "pkgId": "System.ValueTuple@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Diagnostics.EventLog@4.6.0",
+          "pkgId": "System.Diagnostics.EventLog@4.6.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@5.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Win32.Registry@4.7.0"
+            },
+            {
+              "nodeId": "System.Security.Principal.Windows@5.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.IdentityModel.Tokens.Jwt@6.35.0",
+          "pkgId": "System.IdentityModel.Tokens.Jwt@6.35.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.IdentityModel.JsonWebTokens@6.35.0"
+            },
+            {
+              "nodeId": "Microsoft.IdentityModel.Tokens@6.35.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.IdentityModel.JsonWebTokens@6.35.0",
+          "pkgId": "Microsoft.IdentityModel.JsonWebTokens@6.35.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.IdentityModel.Tokens@6.35.0"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.Encodings.Web@4.7.2"
+            },
+            {
+              "nodeId": "System.Text.Json@4.7.2"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.IdentityModel.Tokens@6.35.0",
+          "pkgId": "Microsoft.IdentityModel.Tokens@6.35.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.CSharp@4.7.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.IdentityModel.Logging@6.35.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Cng@5.0.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.CSharp@4.7.0:pruned",
+          "pkgId": "Microsoft.CSharp@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.IdentityModel.Logging@6.35.0",
+          "pkgId": "Microsoft.IdentityModel.Logging@6.35.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.IdentityModel.Abstractions@6.35.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.IdentityModel.Abstractions@6.35.0",
+          "pkgId": "Microsoft.IdentityModel.Abstractions@6.35.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Pkcs@8.0.0:pruned",
+          "pkgId": "System.Security.Cryptography.Pkcs@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Security.Principal.Windows@5.0.0:pruned",
+          "pkgId": "System.Security.Principal.Windows@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.ServiceModel.Syndication@4.5.0",
+          "pkgId": "System.ServiceModel.Syndication@4.5.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Runtime.CompilerServices.Unsafe@6.0.0:pruned",
+          "pkgId": "System.Runtime.CompilerServices.Unsafe@6.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Threading.AccessControl@4.5.0",
+          "pkgId": "System.Threading.AccessControl@4.5.0",
+          "deps": [
+            {
+              "nodeId": "System.Security.AccessControl@6.0.0"
+            },
+            {
+              "nodeId": "System.Security.Principal.Windows@5.0.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Ude.NetStandard@1.2.0",
+          "pkgId": "Ude.NetStandard@1.2.0",
+          "deps": []
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/dotnetcore/dotnet_8_with_azure_functions/expected_depgraph-v3.json
+++ b/test/fixtures/dotnetcore/dotnet_8_with_azure_functions/expected_depgraph-v3.json
@@ -20,6 +20,314 @@
         }
       },
       {
+        "id": "Microsoft.Azure.Functions.Analyzers@1.0.0",
+        "info": {
+          "name": "Microsoft.Azure.Functions.Analyzers",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Azure.WebJobs@3.0.32",
+        "info": {
+          "name": "Microsoft.Azure.WebJobs",
+          "version": "3.0.32"
+        }
+      },
+      {
+        "id": "Microsoft.Azure.WebJobs.Core@3.0.32",
+        "info": {
+          "name": "Microsoft.Azure.WebJobs.Core",
+          "version": "3.0.32"
+        }
+      },
+      {
+        "id": "System.ComponentModel.Annotations@4.5.0",
+        "info": {
+          "name": "System.ComponentModel.Annotations",
+          "version": "4.5.0"
+        }
+      },
+      {
+        "id": "System.Diagnostics.TraceSource@8.0.0",
+        "info": {
+          "name": "System.Diagnostics.TraceSource",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.NETCore.Platforms@1.1.1",
+        "info": {
+          "name": "Microsoft.NETCore.Platforms",
+          "version": "1.1.1"
+        }
+      },
+      {
+        "id": "System.Collections@8.0.0",
+        "info": {
+          "name": "System.Collections",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.NETCore.Targets@1.1.3",
+        "info": {
+          "name": "Microsoft.NETCore.Targets",
+          "version": "1.1.3"
+        }
+      },
+      {
+        "id": "System.Runtime@8.0.0",
+        "info": {
+          "name": "System.Runtime",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Diagnostics.Debug@8.0.0",
+        "info": {
+          "name": "System.Diagnostics.Debug",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Globalization@8.0.0",
+        "info": {
+          "name": "System.Globalization",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Resources.ResourceManager@8.0.0",
+        "info": {
+          "name": "System.Resources.ResourceManager",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection@8.0.0",
+        "info": {
+          "name": "System.Reflection",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.IO@8.0.0",
+        "info": {
+          "name": "System.IO",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Text.Encoding@8.0.0",
+        "info": {
+          "name": "System.Text.Encoding",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Threading.Tasks@8.0.0",
+        "info": {
+          "name": "System.Threading.Tasks",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Reflection.Primitives@8.0.0",
+        "info": {
+          "name": "System.Reflection.Primitives",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Runtime.Extensions@8.0.0",
+        "info": {
+          "name": "System.Runtime.Extensions",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Threading@8.0.0",
+        "info": {
+          "name": "System.Threading",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Configuration@2.1.1",
+        "info": {
+          "name": "Microsoft.Extensions.Configuration",
+          "version": "2.1.1"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Configuration.Abstractions@2.2.0",
+        "info": {
+          "name": "Microsoft.Extensions.Configuration.Abstractions",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Primitives@2.2.0",
+        "info": {
+          "name": "Microsoft.Extensions.Primitives",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "System.Memory@4.5.1",
+        "info": {
+          "name": "System.Memory",
+          "version": "4.5.1"
+        }
+      },
+      {
+        "id": "System.Runtime.CompilerServices.Unsafe@4.5.1",
+        "info": {
+          "name": "System.Runtime.CompilerServices.Unsafe",
+          "version": "4.5.1"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Configuration.EnvironmentVariables@2.1.0",
+        "info": {
+          "name": "Microsoft.Extensions.Configuration.EnvironmentVariables",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Configuration.Json@2.1.0",
+        "info": {
+          "name": "Microsoft.Extensions.Configuration.Json",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Configuration.FileExtensions@2.1.0",
+        "info": {
+          "name": "Microsoft.Extensions.Configuration.FileExtensions",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.FileProviders.Physical@2.1.0",
+        "info": {
+          "name": "Microsoft.Extensions.FileProviders.Physical",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.FileProviders.Abstractions@2.2.0",
+        "info": {
+          "name": "Microsoft.Extensions.FileProviders.Abstractions",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.FileSystemGlobbing@2.1.0",
+        "info": {
+          "name": "Microsoft.Extensions.FileSystemGlobbing",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "Newtonsoft.Json@13.0.1",
+        "info": {
+          "name": "Newtonsoft.Json",
+          "version": "13.0.1"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Hosting@2.1.0",
+        "info": {
+          "name": "Microsoft.Extensions.Hosting",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.DependencyInjection@2.2.0",
+        "info": {
+          "name": "Microsoft.Extensions.DependencyInjection",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.DependencyInjection.Abstractions@2.2.0",
+        "info": {
+          "name": "Microsoft.Extensions.DependencyInjection.Abstractions",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Hosting.Abstractions@2.2.0",
+        "info": {
+          "name": "Microsoft.Extensions.Hosting.Abstractions",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Logging.Abstractions@2.2.0",
+        "info": {
+          "name": "Microsoft.Extensions.Logging.Abstractions",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Logging@2.1.1",
+        "info": {
+          "name": "Microsoft.Extensions.Logging",
+          "version": "2.1.1"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Configuration.Binder@2.1.1",
+        "info": {
+          "name": "Microsoft.Extensions.Configuration.Binder",
+          "version": "2.1.1"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Options@2.2.0",
+        "info": {
+          "name": "Microsoft.Extensions.Options",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Logging.Configuration@2.1.0",
+        "info": {
+          "name": "Microsoft.Extensions.Logging.Configuration",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.Options.ConfigurationExtensions@2.1.0",
+        "info": {
+          "name": "Microsoft.Extensions.Options.ConfigurationExtensions",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "System.Memory.Data@1.0.1",
+        "info": {
+          "name": "System.Memory.Data",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "id": "System.Text.Json@4.6.0",
+        "info": {
+          "name": "System.Text.Json",
+          "version": "4.6.0"
+        }
+      },
+      {
+        "id": "System.Threading.Tasks.Dataflow@4.8.0",
+        "info": {
+          "name": "System.Threading.Tasks.Dataflow",
+          "version": "4.8.0"
+        }
+      },
+      {
         "id": "Microsoft.Azure.WebJobs.Extensions@3.0.6",
         "info": {
           "name": "Microsoft.Azure.WebJobs.Extensions",
@@ -62,13 +370,6 @@
         }
       },
       {
-        "id": "System.Collections@8.0.0",
-        "info": {
-          "name": "System.Collections",
-          "version": "8.0.0"
-        }
-      },
-      {
         "id": "System.Collections.Concurrent@8.0.0",
         "info": {
           "name": "System.Collections.Concurrent",
@@ -76,79 +377,9 @@
         }
       },
       {
-        "id": "System.Diagnostics.Debug@8.0.0",
-        "info": {
-          "name": "System.Diagnostics.Debug",
-          "version": "8.0.0"
-        }
-      },
-      {
         "id": "System.Diagnostics.Tracing@8.0.0",
         "info": {
           "name": "System.Diagnostics.Tracing",
-          "version": "8.0.0"
-        }
-      },
-      {
-        "id": "System.Globalization@8.0.0",
-        "info": {
-          "name": "System.Globalization",
-          "version": "8.0.0"
-        }
-      },
-      {
-        "id": "System.Reflection@8.0.0",
-        "info": {
-          "name": "System.Reflection",
-          "version": "8.0.0"
-        }
-      },
-      {
-        "id": "System.IO@8.0.0",
-        "info": {
-          "name": "System.IO",
-          "version": "8.0.0"
-        }
-      },
-      {
-        "id": "System.Text.Encoding@8.0.0",
-        "info": {
-          "name": "System.Text.Encoding",
-          "version": "8.0.0"
-        }
-      },
-      {
-        "id": "System.Threading.Tasks@8.0.0",
-        "info": {
-          "name": "System.Threading.Tasks",
-          "version": "8.0.0"
-        }
-      },
-      {
-        "id": "System.Reflection.Primitives@8.0.0",
-        "info": {
-          "name": "System.Reflection.Primitives",
-          "version": "8.0.0"
-        }
-      },
-      {
-        "id": "System.Resources.ResourceManager@8.0.0",
-        "info": {
-          "name": "System.Resources.ResourceManager",
-          "version": "8.0.0"
-        }
-      },
-      {
-        "id": "System.Runtime.Extensions@8.0.0",
-        "info": {
-          "name": "System.Runtime.Extensions",
-          "version": "8.0.0"
-        }
-      },
-      {
-        "id": "System.Threading@8.0.0",
-        "info": {
-          "name": "System.Threading",
           "version": "8.0.0"
         }
       },
@@ -177,6 +408,13 @@
         "id": "System.IO.Compression@8.0.0",
         "info": {
           "name": "System.IO.Compression",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Buffers@8.0.0",
+        "info": {
+          "name": "System.Buffers",
           "version": "8.0.0"
         }
       },
@@ -272,6 +510,27 @@
         }
       },
       {
+        "id": "System.Net.Http@8.0.0",
+        "info": {
+          "name": "System.Net.Http",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Diagnostics.DiagnosticSource@8.0.0",
+        "info": {
+          "name": "System.Diagnostics.DiagnosticSource",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Globalization.Extensions@8.0.0",
+        "info": {
+          "name": "System.Globalization.Extensions",
+          "version": "8.0.0"
+        }
+      },
+      {
         "id": "System.Net.Primitives@8.0.0",
         "info": {
           "name": "System.Net.Primitives",
@@ -279,16 +538,9 @@
         }
       },
       {
-        "id": "System.Net.Sockets@8.0.0",
+        "id": "System.Security.Cryptography.Algorithms@8.0.0",
         "info": {
-          "name": "System.Net.Sockets",
-          "version": "8.0.0"
-        }
-      },
-      {
-        "id": "System.Runtime.InteropServices.RuntimeInformation@8.0.0",
-        "info": {
-          "name": "System.Runtime.InteropServices.RuntimeInformation",
+          "name": "System.Security.Cryptography.Algorithms",
           "version": "8.0.0"
         }
       },
@@ -296,13 +548,6 @@
         "id": "System.Runtime.Numerics@8.0.0",
         "info": {
           "name": "System.Runtime.Numerics",
-          "version": "8.0.0"
-        }
-      },
-      {
-        "id": "System.Security.Cryptography.Algorithms@8.0.0",
-        "info": {
-          "name": "System.Security.Cryptography.Algorithms",
           "version": "8.0.0"
         }
       },
@@ -317,6 +562,13 @@
         "id": "System.Security.Cryptography.Primitives@8.0.0",
         "info": {
           "name": "System.Security.Cryptography.Primitives",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Security.Cryptography.OpenSsl@8.0.0",
+        "info": {
+          "name": "System.Security.Cryptography.OpenSsl",
           "version": "8.0.0"
         }
       },
@@ -342,9 +594,16 @@
         }
       },
       {
-        "id": "System.Security.Cryptography.OpenSsl@8.0.0",
+        "id": "System.Net.Sockets@8.0.0",
         "info": {
-          "name": "System.Security.Cryptography.OpenSsl",
+          "name": "System.Net.Sockets",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Runtime.InteropServices.RuntimeInformation@8.0.0",
+        "info": {
+          "name": "System.Runtime.InteropServices.RuntimeInformation",
           "version": "8.0.0"
         }
       },
@@ -352,6 +611,13 @@
         "id": "System.Text.Encoding.Extensions@8.0.0",
         "info": {
           "name": "System.Text.Encoding.Extensions",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "System.Text.RegularExpressions@8.0.0",
+        "info": {
+          "name": "System.Text.RegularExpressions",
           "version": "8.0.0"
         }
       },
@@ -370,6 +636,13 @@
         }
       },
       {
+        "id": "System.Threading.Tasks.Extensions@8.0.0",
+        "info": {
+          "name": "System.Threading.Tasks.Extensions",
+          "version": "8.0.0"
+        }
+      },
+      {
         "id": "System.Xml.XDocument@8.0.0",
         "info": {
           "name": "System.Xml.XDocument",
@@ -384,6 +657,209 @@
         }
       },
       {
+        "id": "Microsoft.Azure.WebJobs.Extensions.Http@3.2.0",
+        "info": {
+          "name": "Microsoft.Azure.WebJobs.Extensions.Http",
+          "version": "3.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNet.WebApi.Client@5.2.8",
+        "info": {
+          "name": "Microsoft.AspNet.WebApi.Client",
+          "version": "5.2.8"
+        }
+      },
+      {
+        "id": "Newtonsoft.Json.Bson@1.0.1",
+        "info": {
+          "name": "Newtonsoft.Json.Bson",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Http@2.2.2",
+        "info": {
+          "name": "Microsoft.AspNetCore.Http",
+          "version": "2.2.2"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Http.Abstractions@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.Http.Abstractions",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Http.Features@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.Http.Features",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "System.Text.Encodings.Web@4.7.2",
+        "info": {
+          "name": "System.Text.Encodings.Web",
+          "version": "4.7.2"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.WebUtilities@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.WebUtilities",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.Net.Http.Headers@2.2.0",
+        "info": {
+          "name": "Microsoft.Net.Http.Headers",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.ObjectPool@2.2.0",
+        "info": {
+          "name": "Microsoft.Extensions.ObjectPool",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Mvc.Formatters.Json@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.Mvc.Formatters.Json",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.JsonPatch@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.JsonPatch",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.CSharp@8.0.0",
+        "info": {
+          "name": "Microsoft.CSharp",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Mvc.Core@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.Mvc.Core",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Authentication.Core@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.Authentication.Core",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Authentication.Abstractions@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.Authentication.Abstractions",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Http.Extensions@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.Http.Extensions",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Authorization.Policy@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.Authorization.Policy",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Authorization@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.Authorization",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Hosting.Abstractions@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.Hosting.Abstractions",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Hosting.Server.Abstractions@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.Hosting.Server.Abstractions",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Mvc.Abstractions@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.Mvc.Abstractions",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Routing.Abstractions@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.Routing.Abstractions",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.ResponseCaching.Abstractions@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.ResponseCaching.Abstractions",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Routing@2.2.2",
+        "info": {
+          "name": "Microsoft.AspNetCore.Routing",
+          "version": "2.2.2"
+        }
+      },
+      {
+        "id": "Microsoft.Extensions.DependencyModel@2.1.0",
+        "info": {
+          "name": "Microsoft.Extensions.DependencyModel",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "Microsoft.DotNet.PlatformAbstractions@2.1.0",
+        "info": {
+          "name": "Microsoft.DotNet.PlatformAbstractions",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "System.Dynamic.Runtime@8.0.0",
+        "info": {
+          "name": "System.Dynamic.Runtime",
+          "version": "8.0.0"
+        }
+      },
+      {
+        "id": "Microsoft.AspNetCore.Mvc.WebApiCompatShim@2.2.0",
+        "info": {
+          "name": "Microsoft.AspNetCore.Mvc.WebApiCompatShim",
+          "version": "2.2.0"
+        }
+      },
+      {
         "id": "Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator@4.0.1",
         "info": {
           "name": "Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator",
@@ -395,62 +871,6 @@
         "info": {
           "name": "System.Runtime.Loader",
           "version": "8.0.0"
-        }
-      },
-      {
-        "id": "Newtonsoft.Json@13.0.1",
-        "info": {
-          "name": "Newtonsoft.Json",
-          "version": "13.0.1"
-        }
-      },
-      {
-        "id": "System.Net.Http@8.0.0",
-        "info": {
-          "name": "System.Net.Http",
-          "version": "8.0.0"
-        }
-      },
-      {
-        "id": "Microsoft.NETCore.Platforms@1.1.1",
-        "info": {
-          "name": "Microsoft.NETCore.Platforms",
-          "version": "1.1.1"
-        }
-      },
-      {
-        "id": "System.Globalization.Extensions@8.0.0",
-        "info": {
-          "name": "System.Globalization.Extensions",
-          "version": "8.0.0"
-        }
-      },
-      {
-        "id": "System.Text.Encodings.Web@4.7.2",
-        "info": {
-          "name": "System.Text.Encodings.Web",
-          "version": "4.7.2"
-        }
-      },
-      {
-        "id": "System.Text.RegularExpressions@8.0.0",
-        "info": {
-          "name": "System.Text.RegularExpressions",
-          "version": "8.0.0"
-        }
-      },
-      {
-        "id": "System.Runtime@8.0.0",
-        "info": {
-          "name": "System.Runtime",
-          "version": "8.0.0"
-        }
-      },
-      {
-        "id": "Microsoft.NETCore.Targets@1.1.3",
-        "info": {
-          "name": "Microsoft.NETCore.Targets",
-          "version": "1.1.3"
         }
       }
     ],
@@ -471,7 +891,16 @@
           "pkgId": "Microsoft.NET.Sdk.Functions@4.3.0",
           "deps": [
             {
+              "nodeId": "Microsoft.Azure.Functions.Analyzers@1.0.0"
+            },
+            {
+              "nodeId": "Microsoft.Azure.WebJobs@3.0.32"
+            },
+            {
               "nodeId": "Microsoft.Azure.WebJobs.Extensions@3.0.6"
+            },
+            {
+              "nodeId": "Microsoft.Azure.WebJobs.Extensions.Http@3.2.0"
             },
             {
               "nodeId": "Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator@4.0.1"
@@ -491,9 +920,722 @@
           ]
         },
         {
+          "nodeId": "Microsoft.Azure.Functions.Analyzers@1.0.0",
+          "pkgId": "Microsoft.Azure.Functions.Analyzers@1.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Azure.WebJobs@3.0.32",
+          "pkgId": "Microsoft.Azure.WebJobs@3.0.32",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Azure.WebJobs.Core@3.0.32"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration@2.1.1"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.EnvironmentVariables@2.1.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Json@2.1.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Hosting@2.1.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging@2.1.1"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Configuration@2.1.0"
+            },
+            {
+              "nodeId": "Newtonsoft.Json@13.0.1"
+            },
+            {
+              "nodeId": "System.Memory.Data@1.0.1"
+            },
+            {
+              "nodeId": "System.Threading.Tasks.Dataflow@4.8.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Azure.WebJobs.Core@3.0.32",
+          "pkgId": "Microsoft.Azure.WebJobs.Core@3.0.32",
+          "deps": [
+            {
+              "nodeId": "System.ComponentModel.Annotations@4.5.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.TraceSource@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.ComponentModel.Annotations@4.5.0",
+          "pkgId": "System.ComponentModel.Annotations@4.5.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Diagnostics.TraceSource@4.3.0",
+          "pkgId": "System.Diagnostics.TraceSource@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.NETCore.Platforms@1.1.1",
+          "pkgId": "Microsoft.NETCore.Platforms@1.1.1",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Collections@4.3.0",
+          "pkgId": "System.Collections@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned",
+          "pkgId": "Microsoft.NETCore.Platforms@1.1.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.NETCore.Targets@1.1.3",
+          "pkgId": "Microsoft.NETCore.Targets@1.1.3",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Runtime@4.3.1",
+          "pkgId": "System.Runtime@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned",
+          "pkgId": "Microsoft.NETCore.Targets@1.1.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Diagnostics.Debug@4.3.0",
+          "pkgId": "System.Diagnostics.Debug@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Globalization@4.3.0",
+          "pkgId": "System.Globalization@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Resources.ResourceManager@4.3.0",
+          "pkgId": "System.Resources.ResourceManager@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Globalization@4.3.0:pruned",
+          "pkgId": "System.Globalization@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Reflection@4.3.0",
+          "pkgId": "System.Reflection@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.IO@4.3.0",
+          "pkgId": "System.IO@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Text.Encoding@4.3.0",
+          "pkgId": "System.Text.Encoding@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Runtime@4.3.1:pruned",
+          "pkgId": "System.Runtime@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Threading.Tasks@4.3.0",
+          "pkgId": "System.Threading.Tasks@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Reflection.Primitives@4.3.0",
+          "pkgId": "System.Reflection.Primitives@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Runtime.Extensions@4.3.0",
+          "pkgId": "System.Runtime.Extensions@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Threading@4.3.0",
+          "pkgId": "System.Threading@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration@2.1.1",
+          "pkgId": "Microsoft.Extensions.Configuration@2.1.1",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@2.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.Abstractions@2.2.0",
+          "pkgId": "Microsoft.Extensions.Configuration.Abstractions@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@2.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Primitives@2.2.0",
+          "pkgId": "Microsoft.Extensions.Primitives@2.2.0",
+          "deps": [
+            {
+              "nodeId": "System.Memory@4.5.1"
+            },
+            {
+              "nodeId": "System.Runtime.CompilerServices.Unsafe@4.5.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Memory@4.5.1",
+          "pkgId": "System.Memory@4.5.1",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Runtime.CompilerServices.Unsafe@4.5.1",
+          "pkgId": "System.Runtime.CompilerServices.Unsafe@4.5.1",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.EnvironmentVariables@2.1.0",
+          "pkgId": "Microsoft.Extensions.Configuration.EnvironmentVariables@2.1.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration@2.1.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration@2.1.1:pruned",
+          "pkgId": "Microsoft.Extensions.Configuration@2.1.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.Json@2.1.0",
+          "pkgId": "Microsoft.Extensions.Configuration.Json@2.1.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration@2.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.FileExtensions@2.1.0"
+            },
+            {
+              "nodeId": "Newtonsoft.Json@13.0.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.FileExtensions@2.1.0",
+          "pkgId": "Microsoft.Extensions.Configuration.FileExtensions@2.1.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration@2.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.FileProviders.Physical@2.1.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.FileProviders.Physical@2.1.0",
+          "pkgId": "Microsoft.Extensions.FileProviders.Physical@2.1.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.FileProviders.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.FileSystemGlobbing@2.1.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.FileProviders.Abstractions@2.2.0",
+          "pkgId": "Microsoft.Extensions.FileProviders.Abstractions@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@2.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.FileSystemGlobbing@2.1.0",
+          "pkgId": "Microsoft.Extensions.FileSystemGlobbing@2.1.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Newtonsoft.Json@13.0.1",
+          "pkgId": "Newtonsoft.Json@13.0.1",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Hosting@2.1.0",
+          "pkgId": "Microsoft.Extensions.Hosting@2.1.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration@2.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.FileProviders.Physical@2.1.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Hosting.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging@2.1.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.DependencyInjection@2.2.0",
+          "pkgId": "Microsoft.Extensions.DependencyInjection@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@2.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@2.2.0",
+          "pkgId": "Microsoft.Extensions.DependencyInjection.Abstractions@2.2.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Hosting.Abstractions@2.2.0",
+          "pkgId": "Microsoft.Extensions.Hosting.Abstractions@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.FileProviders.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@2.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.Abstractions@2.2.0:pruned",
+          "pkgId": "Microsoft.Extensions.Configuration.Abstractions@2.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Logging.Abstractions@2.2.0",
+          "pkgId": "Microsoft.Extensions.Logging.Abstractions@2.2.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Logging@2.1.1",
+          "pkgId": "Microsoft.Extensions.Logging@2.1.1",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Binder@2.1.1"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@2.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Configuration.Binder@2.1.1",
+          "pkgId": "Microsoft.Extensions.Configuration.Binder@2.1.1",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration@2.1.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Options@2.2.0",
+          "pkgId": "Microsoft.Extensions.Options@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@2.2.0"
+            },
+            {
+              "nodeId": "System.ComponentModel.Annotations@4.5.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@2.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@2.2.0:pruned",
+          "pkgId": "Microsoft.Extensions.DependencyInjection.Abstractions@2.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Logging.Configuration@2.1.0",
+          "pkgId": "Microsoft.Extensions.Logging.Configuration@2.1.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Logging@2.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options.ConfigurationExtensions@2.1.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Logging@2.1.1:pruned",
+          "pkgId": "Microsoft.Extensions.Logging@2.1.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.Options.ConfigurationExtensions@2.1.0",
+          "pkgId": "Microsoft.Extensions.Options.ConfigurationExtensions@2.1.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Binder@2.1.1"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@2.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Memory.Data@1.0.1",
+          "pkgId": "System.Memory.Data@1.0.1",
+          "deps": [
+            {
+              "nodeId": "System.Text.Json@4.6.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Text.Json@4.6.0",
+          "pkgId": "System.Text.Json@4.6.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Threading.Tasks.Dataflow@4.8.0",
+          "pkgId": "System.Threading.Tasks.Dataflow@4.8.0",
+          "deps": []
+        },
+        {
           "nodeId": "Microsoft.Azure.WebJobs.Extensions@3.0.6",
           "pkgId": "Microsoft.Azure.WebJobs.Extensions@3.0.6",
           "deps": [
+            {
+              "nodeId": "Microsoft.Azure.WebJobs@3.0.32:pruned"
+            },
             {
               "nodeId": "Microsoft.Azure.WebJobs.Host.Storage@3.0.14"
             },
@@ -503,9 +1645,22 @@
           ]
         },
         {
+          "nodeId": "Microsoft.Azure.WebJobs@3.0.32:pruned",
+          "pkgId": "Microsoft.Azure.WebJobs@3.0.32",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
           "nodeId": "Microsoft.Azure.WebJobs.Host.Storage@3.0.14",
           "pkgId": "Microsoft.Azure.WebJobs.Host.Storage@3.0.14",
           "deps": [
+            {
+              "nodeId": "Microsoft.Azure.WebJobs@3.0.32:pruned"
+            },
             {
               "nodeId": "WindowsAzure.Storage@9.3.1"
             }
@@ -517,6 +1672,9 @@
           "deps": [
             {
               "nodeId": "NETStandard.Library@1.6.1"
+            },
+            {
+              "nodeId": "Newtonsoft.Json@13.0.1"
             }
           ]
         },
@@ -524,6 +1682,9 @@
           "nodeId": "NETStandard.Library@1.6.1",
           "pkgId": "NETStandard.Library@1.6.1",
           "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1"
+            },
             {
               "nodeId": "Microsoft.Win32.Primitives@4.3.0"
             },
@@ -576,6 +1737,9 @@
               "nodeId": "System.Linq.Expressions@4.3.0"
             },
             {
+              "nodeId": "System.Net.Http@4.3.4"
+            },
+            {
               "nodeId": "System.Net.Primitives@4.3.0"
             },
             {
@@ -595,6 +1759,9 @@
             },
             {
               "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1"
             },
             {
               "nodeId": "System.Runtime.Extensions@4.3.0"
@@ -630,6 +1797,9 @@
               "nodeId": "System.Text.Encoding.Extensions@4.3.0"
             },
             {
+              "nodeId": "System.Text.RegularExpressions@4.3.1"
+            },
+            {
               "nodeId": "System.Threading@4.3.0"
             },
             {
@@ -649,17 +1819,26 @@
         {
           "nodeId": "Microsoft.Win32.Primitives@4.3.0",
           "pkgId": "Microsoft.Win32.Primitives@8.0.0",
-          "deps": []
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1"
+            }
+          ]
         },
         {
           "nodeId": "System.AppContext@4.3.0",
           "pkgId": "System.AppContext@8.0.0",
-          "deps": []
-        },
-        {
-          "nodeId": "System.Collections@4.3.0",
-          "pkgId": "System.Collections@8.0.0",
-          "deps": []
+          "deps": [
+            {
+              "nodeId": "System.Runtime@4.3.1"
+            }
+          ]
         },
         {
           "nodeId": "System.Collections.Concurrent@4.3.0",
@@ -684,6 +1863,9 @@
               "nodeId": "System.Resources.ResourceManager@4.3.0"
             },
             {
+              "nodeId": "System.Runtime@4.3.1"
+            },
+            {
               "nodeId": "System.Runtime.Extensions@4.3.0"
             },
             {
@@ -705,6 +1887,9 @@
               "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
             },
             {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
               "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
             }
           ]
@@ -720,86 +1905,19 @@
           }
         },
         {
-          "nodeId": "System.Diagnostics.Debug@4.3.0",
-          "pkgId": "System.Diagnostics.Debug@8.0.0",
-          "deps": []
-        },
-        {
           "nodeId": "System.Diagnostics.Tracing@4.3.0",
           "pkgId": "System.Diagnostics.Tracing@8.0.0",
-          "deps": []
-        },
-        {
-          "nodeId": "System.Globalization@4.3.0",
-          "pkgId": "System.Globalization@8.0.0",
-          "deps": []
-        },
-        {
-          "nodeId": "System.Reflection@4.3.0",
-          "pkgId": "System.Reflection@8.0.0",
           "deps": [
             {
-              "nodeId": "System.IO@4.3.0"
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
             },
             {
-              "nodeId": "System.Reflection.Primitives@4.3.0"
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3"
             },
             {
-              "nodeId": "System.IO@4.3.0:pruned"
+              "nodeId": "System.Runtime@4.3.1"
             }
           ]
-        },
-        {
-          "nodeId": "System.IO@4.3.0",
-          "pkgId": "System.IO@8.0.0",
-          "deps": [
-            {
-              "nodeId": "System.Text.Encoding@4.3.0"
-            },
-            {
-              "nodeId": "System.Threading.Tasks@4.3.0"
-            }
-          ]
-        },
-        {
-          "nodeId": "System.Text.Encoding@4.3.0",
-          "pkgId": "System.Text.Encoding@8.0.0",
-          "deps": []
-        },
-        {
-          "nodeId": "System.Threading.Tasks@4.3.0",
-          "pkgId": "System.Threading.Tasks@8.0.0",
-          "deps": []
-        },
-        {
-          "nodeId": "System.Reflection.Primitives@4.3.0",
-          "pkgId": "System.Reflection.Primitives@8.0.0",
-          "deps": []
-        },
-        {
-          "nodeId": "System.Resources.ResourceManager@4.3.0",
-          "pkgId": "System.Resources.ResourceManager@8.0.0",
-          "deps": [
-            {
-              "nodeId": "System.Globalization@4.3.0:pruned"
-            },
-            {
-              "nodeId": "System.Reflection@4.3.0:pruned"
-            },
-            {
-              "nodeId": "System.Reflection@4.3.0"
-            }
-          ]
-        },
-        {
-          "nodeId": "System.Globalization@4.3.0:pruned",
-          "pkgId": "System.Globalization@8.0.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
         },
         {
           "nodeId": "System.Reflection@4.3.0:pruned",
@@ -812,25 +1930,20 @@
           }
         },
         {
-          "nodeId": "System.Runtime.Extensions@4.3.0",
-          "pkgId": "System.Runtime.Extensions@8.0.0",
-          "deps": []
-        },
-        {
-          "nodeId": "System.Threading@4.3.0",
-          "pkgId": "System.Threading@8.0.0",
-          "deps": [
-            {
-              "nodeId": "System.Threading.Tasks@4.3.0"
-            }
-          ]
-        },
-        {
           "nodeId": "System.Console@4.3.0",
           "pkgId": "System.Console@8.0.0",
           "deps": [
             {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3"
+            },
+            {
               "nodeId": "System.IO@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1"
             },
             {
               "nodeId": "System.Text.Encoding@4.3.0"
@@ -840,14 +1953,36 @@
         {
           "nodeId": "System.Diagnostics.Tools@4.3.0",
           "pkgId": "System.Diagnostics.Tools@8.0.0",
-          "deps": []
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1"
+            }
+          ]
         },
         {
           "nodeId": "System.Globalization.Calendars@4.3.0",
           "pkgId": "System.Globalization.Calendars@8.0.0",
           "deps": [
             {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3"
+            },
+            {
               "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
             }
           ]
         },
@@ -855,6 +1990,12 @@
           "nodeId": "System.IO.Compression@4.3.0",
           "pkgId": "System.IO.Compression@8.0.0",
           "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "System.Buffers@4.5.0"
+            },
             {
               "nodeId": "System.Collections@4.3.0:pruned"
             },
@@ -866,6 +2007,9 @@
             },
             {
               "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1"
             },
             {
               "nodeId": "System.Runtime.Extensions@4.3.0"
@@ -886,6 +2030,11 @@
               "nodeId": "System.Threading.Tasks@4.3.0"
             }
           ]
+        },
+        {
+          "nodeId": "System.Buffers@4.5.0",
+          "pkgId": "System.Buffers@8.0.0",
+          "deps": []
         },
         {
           "nodeId": "System.Diagnostics.Debug@4.3.0:pruned",
@@ -910,12 +2059,31 @@
         {
           "nodeId": "System.Runtime.Handles@4.3.0",
           "pkgId": "System.Runtime.Handles@8.0.0",
-          "deps": []
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3:pruned"
+            }
+          ]
         },
         {
           "nodeId": "System.Runtime.InteropServices@4.3.0",
           "pkgId": "System.Runtime.InteropServices@8.0.0",
           "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3"
+            },
             {
               "nodeId": "System.Reflection@4.3.0"
             },
@@ -923,7 +2091,13 @@
               "nodeId": "System.Reflection.Primitives@4.3.0"
             },
             {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
               "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0"
             },
             {
               "nodeId": "System.Reflection@4.3.0:pruned"
@@ -932,7 +2106,10 @@
               "nodeId": "System.Reflection.Primitives@4.3.0:pruned"
             },
             {
-              "nodeId": "System.Runtime.Handles@4.3.0"
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1"
             }
           ]
         },
@@ -951,6 +2128,9 @@
           "pkgId": "System.IO.Compression.ZipFile@8.0.0",
           "deps": [
             {
+              "nodeId": "System.Buffers@4.5.0"
+            },
+            {
               "nodeId": "System.IO@4.3.0:pruned"
             },
             {
@@ -964,6 +2144,9 @@
             },
             {
               "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1"
             },
             {
               "nodeId": "System.Runtime.Extensions@4.3.0"
@@ -988,10 +2171,19 @@
           "pkgId": "System.IO.FileSystem@8.0.0",
           "deps": [
             {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3"
+            },
+            {
               "nodeId": "System.IO@4.3.0:pruned"
             },
             {
               "nodeId": "System.IO.FileSystem.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1"
             },
             {
               "nodeId": "System.Runtime.Handles@4.3.0"
@@ -1001,13 +2193,23 @@
             },
             {
               "nodeId": "System.Threading.Tasks@4.3.0"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1"
             }
           ]
         },
         {
           "nodeId": "System.IO.FileSystem.Primitives@4.3.0",
           "pkgId": "System.IO.FileSystem.Primitives@8.0.0",
-          "deps": []
+          "deps": [
+            {
+              "nodeId": "System.Runtime@4.3.1"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            }
+          ]
         },
         {
           "nodeId": "System.Linq@4.3.0",
@@ -1023,10 +2225,19 @@
               "nodeId": "System.Resources.ResourceManager@4.3.0"
             },
             {
+              "nodeId": "System.Runtime@4.3.1"
+            },
+            {
               "nodeId": "System.Runtime.Extensions@4.3.0"
             },
             {
+              "nodeId": "System.Collections@4.3.0"
+            },
+            {
               "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
             },
             {
               "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
@@ -1080,10 +2291,16 @@
               "nodeId": "System.Resources.ResourceManager@4.3.0"
             },
             {
+              "nodeId": "System.Runtime@4.3.1"
+            },
+            {
               "nodeId": "System.Runtime.Extensions@4.3.0"
             },
             {
               "nodeId": "System.Threading@4.3.0"
+            },
+            {
+              "nodeId": "System.IO@4.3.0"
             }
           ]
         },
@@ -1111,6 +2328,9 @@
               "nodeId": "System.Resources.ResourceManager@4.3.0"
             },
             {
+              "nodeId": "System.Runtime@4.3.1"
+            },
+            {
               "nodeId": "System.Threading@4.3.0"
             }
           ]
@@ -1130,6 +2350,12 @@
             },
             {
               "nodeId": "System.Reflection.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1"
+            },
+            {
+              "nodeId": "System.IO@4.3.0"
             }
           ]
         },
@@ -1142,6 +2368,9 @@
             },
             {
               "nodeId": "System.Reflection.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1"
             }
           ]
         },
@@ -1157,6 +2386,9 @@
             },
             {
               "nodeId": "System.Reflection.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1"
             }
           ]
         },
@@ -1175,7 +2407,19 @@
           "pkgId": "System.Reflection.Extensions@8.0.0",
           "deps": [
             {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3"
+            },
+            {
               "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1"
             }
           ]
         },
@@ -1185,77 +2429,229 @@
           "deps": [
             {
               "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0"
             }
           ]
+        },
+        {
+          "nodeId": "System.Net.Http@4.3.4",
+          "pkgId": "System.Net.Http@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Diagnostics.DiagnosticSource@4.5.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.Tracing@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO.FileSystem@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Net.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Algorithms@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.OpenSsl@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.X509Certificates@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.Tracing@4.3.0"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0"
+            },
+            {
+              "nodeId": "System.IO@4.3.0"
+            },
+            {
+              "nodeId": "System.IO.FileSystem@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Diagnostics.DiagnosticSource@4.5.0",
+          "pkgId": "System.Diagnostics.DiagnosticSource@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "System.Diagnostics.Tracing@4.3.0:pruned",
+          "pkgId": "System.Diagnostics.Tracing@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Globalization.Extensions@4.3.0",
+          "pkgId": "System.Globalization.Extensions@8.0.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.IO.FileSystem@4.3.0:pruned",
+          "pkgId": "System.IO.FileSystem@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
         },
         {
           "nodeId": "System.Net.Primitives@4.3.0",
           "pkgId": "System.Net.Primitives@8.0.0",
           "deps": [
             {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1"
+            },
+            {
               "nodeId": "System.Runtime.Handles@4.3.0"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1"
             }
           ]
         },
         {
-          "nodeId": "System.Net.Sockets@4.3.0",
-          "pkgId": "System.Net.Sockets@8.0.0",
+          "nodeId": "System.Security.Cryptography.Algorithms@4.3.0",
+          "pkgId": "System.Security.Cryptography.Algorithms@8.0.0",
           "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
             {
               "nodeId": "System.IO@4.3.0:pruned"
-            },
-            {
-              "nodeId": "System.Net.Primitives@4.3.0:pruned"
-            },
-            {
-              "nodeId": "System.Threading.Tasks@4.3.0"
-            }
-          ]
-        },
-        {
-          "nodeId": "System.Net.Primitives@4.3.0:pruned",
-          "pkgId": "System.Net.Primitives@8.0.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
-          "nodeId": "System.Reflection.Primitives@4.3.0:pruned",
-          "pkgId": "System.Reflection.Primitives@8.0.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
-          "nodeId": "System.Runtime.InteropServices.RuntimeInformation@4.3.0",
-          "pkgId": "System.Runtime.InteropServices.RuntimeInformation@8.0.0",
-          "deps": [
-            {
-              "nodeId": "System.Reflection@4.3.0:pruned"
-            },
-            {
-              "nodeId": "System.Reflection.Extensions@4.3.0:pruned"
             },
             {
               "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
             },
             {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
               "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
             },
             {
-              "nodeId": "System.Threading@4.3.0"
+              "nodeId": "System.Runtime.Numerics@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Numerics@4.3.0:pruned"
             }
           ]
         },
         {
-          "nodeId": "System.Reflection.Extensions@4.3.0:pruned",
-          "pkgId": "System.Reflection.Extensions@8.0.0",
+          "nodeId": "System.Resources.ResourceManager@4.3.0:pruned",
+          "pkgId": "System.Resources.ResourceManager@8.0.0",
           "deps": [],
           "info": {
             "labels": {
@@ -1264,8 +2660,8 @@
           }
         },
         {
-          "nodeId": "System.Resources.ResourceManager@4.3.0:pruned",
-          "pkgId": "System.Resources.ResourceManager@8.0.0",
+          "nodeId": "System.Runtime.Extensions@4.3.0:pruned",
+          "pkgId": "System.Runtime.Extensions@8.0.0",
           "deps": [],
           "info": {
             "labels": {
@@ -1294,73 +2690,20 @@
               "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
             },
             {
-              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
-            }
-          ]
-        },
-        {
-          "nodeId": "System.Runtime.Extensions@4.3.0:pruned",
-          "pkgId": "System.Runtime.Extensions@8.0.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
-          "nodeId": "System.Security.Cryptography.Algorithms@4.3.0",
-          "pkgId": "System.Security.Cryptography.Algorithms@8.0.0",
-          "deps": [
-            {
-              "nodeId": "System.Collections@4.3.0:pruned"
-            },
-            {
-              "nodeId": "System.IO@4.3.0:pruned"
-            },
-            {
-              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+              "nodeId": "System.Runtime@4.3.1:pruned"
             },
             {
               "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
-            },
-            {
-              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
-            },
-            {
-              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
-            },
-            {
-              "nodeId": "System.Runtime.Numerics@4.3.0:pruned"
-            },
-            {
-              "nodeId": "System.Security.Cryptography.Encoding@4.3.0"
-            },
-            {
-              "nodeId": "System.Security.Cryptography.Primitives@4.3.0"
-            },
-            {
-              "nodeId": "System.Text.Encoding@4.3.0"
-            },
-            {
-              "nodeId": "System.Runtime.Numerics@4.3.0"
             }
           ]
-        },
-        {
-          "nodeId": "System.Runtime.Numerics@4.3.0:pruned",
-          "pkgId": "System.Runtime.Numerics@8.0.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
         },
         {
           "nodeId": "System.Security.Cryptography.Encoding@4.3.0",
           "pkgId": "System.Security.Cryptography.Encoding@8.0.0",
           "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
             {
               "nodeId": "System.Collections@4.3.0:pruned"
             },
@@ -1372,6 +2715,9 @@
             },
             {
               "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
             },
             {
               "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
@@ -1423,6 +2769,9 @@
               "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
             },
             {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
               "nodeId": "System.Threading@4.3.0"
             },
             {
@@ -1431,9 +2780,80 @@
           ]
         },
         {
+          "nodeId": "System.Security.Cryptography.OpenSsl@4.3.0",
+          "pkgId": "System.Security.Cryptography.OpenSsl@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.IO@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime.Numerics@4.3.0"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Algorithms@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Encoding@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Text.Encoding@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Numerics@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Algorithms@4.3.0:pruned",
+          "pkgId": "System.Security.Cryptography.Algorithms@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Security.Cryptography.Encoding@4.3.0:pruned",
+          "pkgId": "System.Security.Cryptography.Encoding@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
           "nodeId": "System.Security.Cryptography.X509Certificates@4.3.0",
           "pkgId": "System.Security.Cryptography.X509Certificates@8.0.0",
           "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
             {
               "nodeId": "System.Collections@4.3.0:pruned"
             },
@@ -1459,6 +2879,9 @@
               "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
             },
             {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
               "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
             },
             {
@@ -1468,7 +2891,7 @@
               "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
             },
             {
-              "nodeId": "System.Runtime.Numerics@4.3.0:pruned"
+              "nodeId": "System.Runtime.Numerics@4.3.0"
             },
             {
               "nodeId": "System.Security.Cryptography.Algorithms@4.3.0:pruned"
@@ -1483,7 +2906,7 @@
               "nodeId": "System.Security.Cryptography.Encoding@4.3.0:pruned"
             },
             {
-              "nodeId": "System.Security.Cryptography.OpenSsl@4.3.0"
+              "nodeId": "System.Security.Cryptography.OpenSsl@4.3.0:pruned"
             },
             {
               "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned"
@@ -1495,32 +2918,22 @@
               "nodeId": "System.Threading@4.3.0"
             },
             {
+              "nodeId": "System.Runtime.Numerics@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Security.Cryptography.OpenSsl@4.3.0"
+            },
+            {
               "nodeId": "System.Globalization.Calendars@4.3.0"
             },
             {
               "nodeId": "System.IO.FileSystem.Primitives@4.3.0"
-            },
-            {
-              "nodeId": "System.Runtime.Numerics@4.3.0"
-            },
-            {
-              "nodeId": "System.Security.Cryptography.OpenSsl@4.3.0:pruned"
             }
           ]
         },
         {
           "nodeId": "System.Globalization.Calendars@4.3.0:pruned",
           "pkgId": "System.Globalization.Calendars@8.0.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
-          "nodeId": "System.IO.FileSystem@4.3.0:pruned",
-          "pkgId": "System.IO.FileSystem@8.0.0",
           "deps": [],
           "info": {
             "labels": {
@@ -1539,24 +2952,20 @@
           }
         },
         {
-          "nodeId": "System.Security.Cryptography.Algorithms@4.3.0:pruned",
-          "pkgId": "System.Security.Cryptography.Algorithms@8.0.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
           "nodeId": "System.Security.Cryptography.Cng@4.3.0",
           "pkgId": "System.Security.Cryptography.Cng@8.0.0",
           "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
             {
               "nodeId": "System.IO@4.3.0:pruned"
             },
             {
               "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
             },
             {
               "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
@@ -1582,16 +2991,6 @@
           ]
         },
         {
-          "nodeId": "System.Security.Cryptography.Encoding@4.3.0:pruned",
-          "pkgId": "System.Security.Cryptography.Encoding@8.0.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
           "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned",
           "pkgId": "System.Security.Cryptography.Primitives@8.0.0",
           "deps": [],
@@ -1606,13 +3005,19 @@
           "pkgId": "System.Security.Cryptography.Csp@8.0.0",
           "deps": [
             {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
               "nodeId": "System.IO@4.3.0:pruned"
             },
             {
-              "nodeId": "System.Reflection@4.3.0:pruned"
+              "nodeId": "System.Reflection@4.3.0"
             },
             {
               "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
             },
             {
               "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
@@ -1639,59 +3044,133 @@
               "nodeId": "System.Threading@4.3.0"
             },
             {
-              "nodeId": "System.Reflection@4.3.0"
+              "nodeId": "System.Reflection@4.3.0:pruned"
             }
           ]
         },
         {
-          "nodeId": "System.Security.Cryptography.OpenSsl@4.3.0",
+          "nodeId": "System.Security.Cryptography.OpenSsl@4.3.0:pruned",
           "pkgId": "System.Security.Cryptography.OpenSsl@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Net.Sockets@4.3.0",
+          "pkgId": "System.Net.Sockets@8.0.0",
           "deps": [
             {
-              "nodeId": "System.Collections@4.3.0:pruned"
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3"
             },
             {
               "nodeId": "System.IO@4.3.0:pruned"
             },
             {
+              "nodeId": "System.Net.Primitives@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1"
+            },
+            {
+              "nodeId": "System.Threading.Tasks@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Net.Primitives@4.3.0:pruned",
+          "pkgId": "System.Net.Primitives@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Reflection.Primitives@4.3.0:pruned",
+          "pkgId": "System.Reflection.Primitives@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Runtime.InteropServices.RuntimeInformation@4.3.0",
+          "pkgId": "System.Runtime.InteropServices.RuntimeInformation@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Reflection@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Reflection.Extensions@4.3.0:pruned"
+            },
+            {
               "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
             },
             {
-              "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
-            },
-            {
-              "nodeId": "System.Runtime.Handles@4.3.0:pruned"
+              "nodeId": "System.Runtime@4.3.1:pruned"
             },
             {
               "nodeId": "System.Runtime.InteropServices@4.3.0:pruned"
             },
             {
-              "nodeId": "System.Runtime.Numerics@4.3.0:pruned"
+              "nodeId": "System.Threading@4.3.0"
             },
             {
-              "nodeId": "System.Security.Cryptography.Algorithms@4.3.0:pruned"
+              "nodeId": "System.Reflection@4.3.0"
             },
             {
-              "nodeId": "System.Security.Cryptography.Encoding@4.3.0:pruned"
+              "nodeId": "System.Reflection.Extensions@4.3.0"
             },
             {
-              "nodeId": "System.Security.Cryptography.Primitives@4.3.0:pruned"
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
             },
             {
-              "nodeId": "System.Text.Encoding@4.3.0"
-            },
-            {
-              "nodeId": "System.Runtime.Numerics@4.3.0"
-            },
-            {
-              "nodeId": "System.Security.Cryptography.Primitives@4.3.0"
+              "nodeId": "System.Runtime@4.3.1"
             }
           ]
+        },
+        {
+          "nodeId": "System.Reflection.Extensions@4.3.0:pruned",
+          "pkgId": "System.Reflection.Extensions@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Runtime.Numerics@4.3.0:pruned",
+          "pkgId": "System.Runtime.Numerics@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
         },
         {
           "nodeId": "System.Text.Encoding.Extensions@4.3.0",
           "pkgId": "System.Text.Encoding.Extensions@8.0.0",
           "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
             {
               "nodeId": "System.Text.Encoding@4.3.0:pruned"
             }
@@ -1708,9 +3187,31 @@
           }
         },
         {
+          "nodeId": "System.Text.RegularExpressions@4.3.1",
+          "pkgId": "System.Text.RegularExpressions@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1"
+            }
+          ]
+        },
+        {
           "nodeId": "System.Threading.Timer@4.3.0",
           "pkgId": "System.Threading.Timer@8.0.0",
-          "deps": []
+          "deps": [
+            {
+              "nodeId": "Microsoft.NETCore.Platforms@1.1.1:pruned"
+            },
+            {
+              "nodeId": "Microsoft.NETCore.Targets@1.1.3"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            }
+          ]
         },
         {
           "nodeId": "System.Xml.ReaderWriter@4.3.0",
@@ -1738,6 +3239,9 @@
               "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
             },
             {
+              "nodeId": "System.Runtime@4.3.1:pruned"
+            },
+            {
               "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
             },
             {
@@ -1750,13 +3254,29 @@
               "nodeId": "System.Text.Encoding.Extensions@4.3.0:pruned"
             },
             {
+              "nodeId": "System.Text.RegularExpressions@4.3.1:pruned"
+            },
+            {
               "nodeId": "System.Threading.Tasks@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Threading.Tasks.Extensions@4.5.1"
             }
           ]
         },
         {
           "nodeId": "System.Text.Encoding.Extensions@4.3.0:pruned",
           "pkgId": "System.Text.Encoding.Extensions@8.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "System.Text.RegularExpressions@4.3.1:pruned",
+          "pkgId": "System.Text.RegularExpressions@8.0.0",
           "deps": [],
           "info": {
             "labels": {
@@ -1773,6 +3293,11 @@
               "pruned": "true"
             }
           }
+        },
+        {
+          "nodeId": "System.Threading.Tasks.Extensions@4.5.1",
+          "pkgId": "System.Threading.Tasks.Extensions@8.0.0",
+          "deps": []
         },
         {
           "nodeId": "System.Xml.XDocument@4.3.0",
@@ -1798,6 +3323,9 @@
             },
             {
               "nodeId": "System.Resources.ResourceManager@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1:pruned"
             },
             {
               "nodeId": "System.Runtime.Extensions@4.3.0:pruned"
@@ -1846,7 +3374,553 @@
         {
           "nodeId": "ncrontab.signed@3.3.0",
           "pkgId": "ncrontab.signed@3.3.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0"
+            },
+            {
+              "nodeId": "System.IO@4.3.0"
+            },
+            {
+              "nodeId": "System.Net.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Azure.WebJobs.Extensions.Http@3.2.0",
+          "pkgId": "Microsoft.Azure.WebJobs.Extensions.Http@3.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.AspNet.WebApi.Client@5.2.8"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Http@2.2.2"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Mvc.Formatters.Json@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Mvc.WebApiCompatShim@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Routing@2.2.2"
+            },
+            {
+              "nodeId": "Microsoft.Azure.WebJobs@3.0.32:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNet.WebApi.Client@5.2.8",
+          "pkgId": "Microsoft.AspNet.WebApi.Client@5.2.8",
+          "deps": [
+            {
+              "nodeId": "Newtonsoft.Json@13.0.1"
+            },
+            {
+              "nodeId": "Newtonsoft.Json.Bson@1.0.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "Newtonsoft.Json.Bson@1.0.1",
+          "pkgId": "Newtonsoft.Json.Bson@1.0.1",
+          "deps": [
+            {
+              "nodeId": "NETStandard.Library@1.6.1"
+            },
+            {
+              "nodeId": "Newtonsoft.Json@13.0.1:pruned"
+            }
+          ]
+        },
+        {
+          "nodeId": "Newtonsoft.Json@13.0.1:pruned",
+          "pkgId": "Newtonsoft.Json@13.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Http@2.2.2",
+          "pkgId": "Microsoft.AspNetCore.Http@2.2.2",
+          "deps": [
+            {
+              "nodeId": "Microsoft.AspNetCore.Http.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.WebUtilities@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.ObjectPool@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Net.Http.Headers@2.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Http.Abstractions@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.Http.Abstractions@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.AspNetCore.Http.Features@2.2.0"
+            },
+            {
+              "nodeId": "System.Text.Encodings.Web@4.7.2"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Http.Features@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.Http.Features@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@2.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Text.Encodings.Web@4.7.2",
+          "pkgId": "System.Text.Encodings.Web@4.7.2",
           "deps": []
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.WebUtilities@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.WebUtilities@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Net.Http.Headers@2.2.0"
+            },
+            {
+              "nodeId": "System.Text.Encodings.Web@4.7.2"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Net.Http.Headers@2.2.0",
+          "pkgId": "Microsoft.Net.Http.Headers@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@2.2.0"
+            },
+            {
+              "nodeId": "System.Buffers@4.5.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.Extensions.ObjectPool@2.2.0",
+          "pkgId": "Microsoft.Extensions.ObjectPool@2.2.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Mvc.Formatters.Json@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.Mvc.Formatters.Json@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.AspNetCore.JsonPatch@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Mvc.Core@2.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.JsonPatch@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.JsonPatch@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.CSharp@4.5.0"
+            },
+            {
+              "nodeId": "Newtonsoft.Json@13.0.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.CSharp@4.5.0",
+          "pkgId": "Microsoft.CSharp@8.0.0",
+          "deps": []
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Mvc.Core@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.Mvc.Core@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.AspNetCore.Authentication.Core@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Authorization.Policy@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Hosting.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Http@2.2.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Http.Extensions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Mvc.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.ResponseCaching.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Routing@2.2.2"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Routing.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyInjection@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.DependencyModel@2.1.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.FileProviders.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.DiagnosticSource@4.5.0"
+            },
+            {
+              "nodeId": "System.Threading.Tasks.Extensions@4.5.1"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Authentication.Core@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.Authentication.Core@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.AspNetCore.Authentication.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Http@2.2.2:pruned"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Http.Extensions@2.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Authentication.Abstractions@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.Authentication.Abstractions@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.AspNetCore.Http.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@2.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Http@2.2.2:pruned",
+          "pkgId": "Microsoft.AspNetCore.Http@2.2.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Http.Extensions@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.Http.Extensions@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.AspNetCore.Http.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.FileProviders.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Net.Http.Headers@2.2.0"
+            },
+            {
+              "nodeId": "System.Buffers@4.5.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Authorization.Policy@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.Authorization.Policy@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.AspNetCore.Authentication.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Authorization@2.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Authorization@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.Authorization@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@2.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Hosting.Abstractions@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.Hosting.Abstractions@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.AspNetCore.Hosting.Server.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Http.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Hosting.Abstractions@2.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Hosting.Server.Abstractions@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.Hosting.Server.Abstractions@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.AspNetCore.Http.Features@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Configuration.Abstractions@2.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Mvc.Abstractions@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.Mvc.Abstractions@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.AspNetCore.Routing.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Net.Http.Headers@2.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Routing.Abstractions@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.Routing.Abstractions@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.AspNetCore.Http.Abstractions@2.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.ResponseCaching.Abstractions@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.ResponseCaching.Abstractions@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.Extensions.Primitives@2.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Routing@2.2.2",
+          "pkgId": "Microsoft.AspNetCore.Routing@2.2.2",
+          "deps": [
+            {
+              "nodeId": "Microsoft.AspNetCore.Http.Extensions@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Routing.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Logging.Abstractions@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.ObjectPool@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.Extensions.Options@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Http.Extensions@2.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Http.Extensions@2.2.0:pruned",
+          "pkgId": "Microsoft.AspNetCore.Http.Extensions@2.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.Extensions.DependencyModel@2.1.0",
+          "pkgId": "Microsoft.Extensions.DependencyModel@2.1.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.DotNet.PlatformAbstractions@2.1.0"
+            },
+            {
+              "nodeId": "Newtonsoft.Json@13.0.1"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0"
+            },
+            {
+              "nodeId": "System.Dynamic.Runtime@4.0.11"
+            },
+            {
+              "nodeId": "System.Linq@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.DotNet.PlatformAbstractions@2.1.0",
+          "pkgId": "Microsoft.DotNet.PlatformAbstractions@2.1.0",
+          "deps": [
+            {
+              "nodeId": "System.AppContext@4.3.0"
+            },
+            {
+              "nodeId": "System.Collections@4.3.0"
+            },
+            {
+              "nodeId": "System.IO@4.3.0"
+            },
+            {
+              "nodeId": "System.IO.FileSystem@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.TypeExtensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime.InteropServices.RuntimeInformation@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "System.Dynamic.Runtime@4.0.11",
+          "pkgId": "System.Dynamic.Runtime@8.0.0",
+          "deps": [
+            {
+              "nodeId": "System.Collections@4.3.0"
+            },
+            {
+              "nodeId": "System.Diagnostics.Debug@4.3.0:pruned"
+            },
+            {
+              "nodeId": "System.Globalization@4.3.0"
+            },
+            {
+              "nodeId": "System.Linq@4.3.0"
+            },
+            {
+              "nodeId": "System.Linq.Expressions@4.3.0"
+            },
+            {
+              "nodeId": "System.ObjectModel@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.Emit@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.Emit.ILGeneration@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.Primitives@4.3.0"
+            },
+            {
+              "nodeId": "System.Reflection.TypeExtensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Resources.ResourceManager@4.3.0"
+            },
+            {
+              "nodeId": "System.Runtime@4.3.1"
+            },
+            {
+              "nodeId": "System.Runtime.Extensions@4.3.0"
+            },
+            {
+              "nodeId": "System.Threading@4.3.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Mvc.WebApiCompatShim@2.2.0",
+          "pkgId": "Microsoft.AspNetCore.Mvc.WebApiCompatShim@2.2.0",
+          "deps": [
+            {
+              "nodeId": "Microsoft.AspNet.WebApi.Client@5.2.8:pruned"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Mvc.Core@2.2.0"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.Mvc.Formatters.Json@2.2.0:pruned"
+            },
+            {
+              "nodeId": "Microsoft.AspNetCore.WebUtilities@2.2.0"
+            }
+          ]
+        },
+        {
+          "nodeId": "Microsoft.AspNet.WebApi.Client@5.2.8:pruned",
+          "pkgId": "Microsoft.AspNet.WebApi.Client@5.2.8",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
+        },
+        {
+          "nodeId": "Microsoft.AspNetCore.Mvc.Formatters.Json@2.2.0:pruned",
+          "pkgId": "Microsoft.AspNetCore.Mvc.Formatters.Json@2.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "pruned": "true"
+            }
+          }
         },
         {
           "nodeId": "Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator@4.0.1",
@@ -1866,156 +3940,11 @@
             },
             {
               "nodeId": "System.Reflection@4.3.0"
-            }
-          ]
-        },
-        {
-          "nodeId": "Newtonsoft.Json@13.0.1",
-          "pkgId": "Newtonsoft.Json@13.0.1",
-          "deps": []
-        },
-        {
-          "nodeId": "System.Net.Http@4.3.4",
-          "pkgId": "System.Net.Http@8.0.0",
-          "deps": [
-            {
-              "nodeId": "Microsoft.NETCore.Platforms@1.1.1"
             },
-            {
-              "nodeId": "System.Collections@4.3.0"
-            },
-            {
-              "nodeId": "System.Diagnostics.Debug@4.3.0"
-            },
-            {
-              "nodeId": "System.Diagnostics.Tracing@4.3.0"
-            },
-            {
-              "nodeId": "System.Globalization@4.3.0"
-            },
-            {
-              "nodeId": "System.Globalization.Extensions@4.3.0"
-            },
-            {
-              "nodeId": "System.IO@4.3.0"
-            },
-            {
-              "nodeId": "System.IO.FileSystem@4.3.0"
-            },
-            {
-              "nodeId": "System.Net.Primitives@4.3.0"
-            },
-            {
-              "nodeId": "System.Resources.ResourceManager@4.3.0"
-            },
-            {
-              "nodeId": "System.Runtime.Extensions@4.3.0"
-            },
-            {
-              "nodeId": "System.Runtime.Handles@4.3.0"
-            },
-            {
-              "nodeId": "System.Runtime.InteropServices@4.3.0"
-            },
-            {
-              "nodeId": "System.Security.Cryptography.Algorithms@4.3.0"
-            },
-            {
-              "nodeId": "System.Security.Cryptography.Encoding@4.3.0"
-            },
-            {
-              "nodeId": "System.Security.Cryptography.OpenSsl@4.3.0"
-            },
-            {
-              "nodeId": "System.Security.Cryptography.Primitives@4.3.0"
-            },
-            {
-              "nodeId": "System.Security.Cryptography.X509Certificates@4.3.0"
-            },
-            {
-              "nodeId": "System.Text.Encoding@4.3.0"
-            },
-            {
-              "nodeId": "System.Threading@4.3.0"
-            },
-            {
-              "nodeId": "System.Threading.Tasks@4.3.0"
-            }
-          ]
-        },
-        {
-          "nodeId": "Microsoft.NETCore.Platforms@1.1.1",
-          "pkgId": "Microsoft.NETCore.Platforms@1.1.1",
-          "deps": []
-        },
-        {
-          "nodeId": "System.Globalization.Extensions@4.3.0",
-          "pkgId": "System.Globalization.Extensions@8.0.0",
-          "deps": [
-            {
-              "nodeId": "System.Globalization@4.3.0:pruned"
-            },
-            {
-              "nodeId": "System.Resources.ResourceManager@4.3.0"
-            },
-            {
-              "nodeId": "System.Runtime.Extensions@4.3.0"
-            },
-            {
-              "nodeId": "System.Runtime.InteropServices@4.3.0"
-            }
-          ]
-        },
-        {
-          "nodeId": "System.Diagnostics.Tracing@4.3.0:pruned",
-          "pkgId": "System.Diagnostics.Tracing@8.0.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
-          "nodeId": "System.Security.Cryptography.OpenSsl@4.3.0:pruned",
-          "pkgId": "System.Security.Cryptography.OpenSsl@8.0.0",
-          "deps": [],
-          "info": {
-            "labels": {
-              "pruned": "true"
-            }
-          }
-        },
-        {
-          "nodeId": "System.Text.Encodings.Web@4.7.2",
-          "pkgId": "System.Text.Encodings.Web@4.7.2",
-          "deps": []
-        },
-        {
-          "nodeId": "System.Text.RegularExpressions@4.3.1",
-          "pkgId": "System.Text.RegularExpressions@8.0.0",
-          "deps": [
             {
               "nodeId": "System.Runtime@4.3.1"
             }
           ]
-        },
-        {
-          "nodeId": "System.Runtime@4.3.1",
-          "pkgId": "System.Runtime@8.0.0",
-          "deps": [
-            {
-              "nodeId": "Microsoft.NETCore.Platforms@1.1.1"
-            },
-            {
-              "nodeId": "Microsoft.NETCore.Targets@1.1.3"
-            }
-          ]
-        },
-        {
-          "nodeId": "Microsoft.NETCore.Targets@1.1.3",
-          "pkgId": "Microsoft.NETCore.Targets@1.1.3",
-          "deps": []
         }
       ]
     }

--- a/test/parsers/parse-core-v2.spec.ts
+++ b/test/parsers/parse-core-v2.spec.ts
@@ -290,6 +290,14 @@ describe('when generating depGraphs and runtime assemblies using the v2 parser',
       targetFramework: 'net9.0',
       manifestFilePath: 'obj/project.assets.json', // Will be resolved to obj/build/intermediate/project.assets.json
     },
+    {
+      description: 'parse .NET 8.0 project with transitive pinned version',
+      projectPath:
+        './test/fixtures/dotnetcore/dotnet_8_transitive_pinned_version',
+      projectFile: 'dotnet_8_transitive_pinned_version.csproj',
+      targetFramework: 'net8.0',
+      manifestFilePath: 'obj/project.assets.json',
+    },
   ])(
     'succeeds given a project file and returns a single dependency graph for single-targetFramework projects: $description - new Parser',
     async ({


### PR DESCRIPTION
**Problem**
Dependencies with pinned versions (exact version constraints like [4.10.3]) were being omitted from dependency graphs due to version resolution mismatches between declared and resolved versions in project.assets.json.

**Root Cause**
When a package uses pinned versions in .csproj:
`<PackageReference Include="System.ServiceModel.Duplex" Version="[4.10.3]" />`
NuGet resolves it to the exact version in targets, but transitive dependencies may still declare older versions in their dependency lists. The parser failed to find these packages because it looked for the declared version instead of the actual resolved version.

**Solution**
Modified dotnet-core-v3-parser.ts to use actual resolved versions from the targets section when looking up dependencies, ensuring pinned dependencies are correctly included regardless of what versions are declared transitively.

**Impact**
✅ Fixes missing pinned dependencies - Packages with exact version constraints now appear in dependency graphs
✅ Accurate dependency resolution - Matches NuGet's actual resolution behavior
✅ Better debugging - Logs when version mismatches are resolved