### PR TITLE
fix: optimise nuget v3 dependencies lookup

### DIFF
--- a/lib/nuget-parser/types.ts
+++ b/lib/nuget-parser/types.ts
@@ -114,4 +114,12 @@ export type Overrides = {
   overrideVersion: string;
 };
 
+export type ResolvedPackagesMap = Record<
+  string,
+  {
+    readonly resolvedVersion: string;
+    readonly target: Target;
+  }
+>;
+
 export type DotnetCoreV2Results = DotnetCoreV2Result[];


### PR DESCRIPTION
Previous [PR](https://github.com/snyk/snyk-nuget-plugin/pull/262) introduced a search that was not optimal. This PR fixed it.