### PR TITLE
fix: Adjusts output logging on dotnet command failure

### DIFF
--- a/lib/nuget-parser/cli/dotnet.ts
+++ b/lib/nuget-parser/cli/dotnet.ts
@@ -98,9 +98,11 @@ async function handle(
       );
     }
 
-    const message = error.stderr || error.stdout;
+    const fullMessage = [error.stderr, error.stdout]
+      .filter(Boolean)
+      .join('\nSTDOUT:\n');
     throw new CliCommandError(
-      `dotnet ${operation} failed with error: ${message}. Command: ${command}, Args: ${JSON.stringify(sanitizeForLogging(args))}, Options: ${JSON.stringify(sanitizeForLogging(options))}`,
+      `dotnet ${operation} failed with error: ${fullMessage}. Command: ${command}, Args: ${JSON.stringify(sanitizeForLogging(args))}, Options: ${JSON.stringify(sanitizeForLogging(options))}`,
     );
   }
 }


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Adds additional logging of stdout on dotnet command failure

#### Any background context you want to provide?

`dotnet run` intermittently fails in some environments for unknown reasons. Logging stdout as well in case that reveals the cause.