### PR TITLE
fix: handle missing dotnet CLI during runtime resolution scans

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -112,6 +112,12 @@ export async function inspect(
       .then(createPackageTree);
   }
 
+  // Capture whether the customer explicitly requested runtime resolution before the
+  // implicit, server-side enablement below can set it. An explicit request is a hard
+  // requirement that must not be silently downgraded when dotnet is missing.
+  const runtimeResolutionExplicitlyRequested =
+    !!options['dotnet-runtime-resolution'];
+
   if (
     options.cliDotnetRuntimeResolutionEnabled &&
     manifestType === ManifestType.DOTNET_CORE &&
@@ -154,7 +160,17 @@ export async function inspect(
       );
     }
 
-    // dotnet is not installed: degrade to the legacy scan so we don't break
+    // An explicit --dotnet-runtime-resolution request cannot be honoured without dotnet.
+    // Fail loudly rather than silently returning a lower-fidelity legacy result.
+    if (runtimeResolutionExplicitlyRequested) {
+      return Promise.reject(
+        new CliCommandError(
+          'The --dotnet-runtime-resolution flag was set, but the dotnet CLI was not found on the PATH. Install the .NET SDK, or remove the flag to fall back to the legacy scan.',
+        ),
+      );
+    }
+
+    // Implicit (server-side) enablement: degrade to the legacy scan so we don't break
     // environments that worked before runtime resolution was enabled for them.
     if (!dotnetFallbackWarned) {
       dotnetFallbackWarned = true;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,5 @@
 import * as nugetParser from './nuget-parser';
+import * as dotnet from './nuget-parser/cli/dotnet';
 import * as path from 'path';
 import * as paketParser from 'snyk-paket-parser';
 import { ManifestType } from './nuget-parser/types';
@@ -9,6 +10,13 @@ import {
   InvalidTargetFile,
 } from './errors';
 import { MultiProjectResult } from '@snyk/cli-interface/legacy/plugin';
+import * as debugModule from 'debug';
+
+const debug = debugModule('snyk');
+
+// Surface the dotnet-missing fallback to the customer at most once per process —
+// inspect() runs per project, so a multi-project scan would otherwise repeat it.
+let dotnetFallbackWarned = false;
 
 function determineManifestType(filename: string): ManifestType {
   switch (true) {
@@ -30,6 +38,38 @@ function determineManifestType(filename: string): ManifestType {
       );
     }
   }
+}
+
+// Runs the dotnet-backed runtime resolution scan and shapes the result into a
+// MultiProjectResult for the CLI or the SCM scanner. Requires the dotnet CLI.
+async function buildRuntimeResolutionResult(
+  root,
+  targetFile,
+  manifestType: ManifestType,
+  options,
+): Promise<MultiProjectResult> {
+  const results = await nugetParser.buildDepGraphFromFiles(
+    root,
+    targetFile,
+    manifestType,
+    options['assets-project-name'],
+    options['project-name-prefix'],
+    options['dotnet-target-framework'],
+  );
+
+  return {
+    plugin: {
+      name: 'snyk-nuget-plugin',
+      targetFile,
+    },
+    scannedProjects: results.map((result) => ({
+      targetFile,
+      depGraph: result.dependencyGraph,
+      meta: {
+        targetRuntime: result.targetFramework,
+      },
+    })),
+  };
 }
 
 export async function inspect(
@@ -100,35 +140,36 @@ export async function inspect(
       );
     }
 
-    const results = await nugetParser.buildDepGraphFromFiles(
-      root,
-      targetFile,
-      manifestType,
-      options['assets-project-name'],
-      options['project-name-prefix'],
-      options['dotnet-target-framework'],
-    );
-
-    // Construct a MultiProjectResult to send to either the CLI or the SCM scanner.
-    const multiProjectResult: MultiProjectResult = {
-      plugin: {
-        name: 'snyk-nuget-plugin',
+    // The runtime resolution flow depends on the dotnet CLI for restore, runtime
+    // assembly resolution and target framework parsing. When dotnet is unavailable
+    // (e.g. a CI step that runs after the build), fall back to the legacy scan of the
+    // existing project.assets.json so we don't break environments that worked before
+    // this flow was enabled.
+    if (await dotnet.isInstalled()) {
+      return buildRuntimeResolutionResult(
+        root,
         targetFile,
-      },
-      scannedProjects: [],
-    };
-
-    for (const result of results) {
-      multiProjectResult.scannedProjects.push({
-        targetFile: targetFile,
-        depGraph: result.dependencyGraph,
-        meta: {
-          targetRuntime: result.targetFramework,
-        },
-      });
+        manifestType,
+        options,
+      );
     }
 
-    return multiProjectResult;
+    // dotnet is not installed: degrade to the legacy scan so we don't break
+    // environments that worked before runtime resolution was enabled for them.
+    if (!dotnetFallbackWarned) {
+      dotnetFallbackWarned = true;
+      console.warn(
+        `\x1b[33m⚠ WARNING\x1b[0m: The dotnet CLI was not found on your PATH. Falling back to a static scan for SDK-style .NET projects — results will not include runtime dependency resolution and may be less complete. Install the .NET SDK and ensure dotnet is on your PATH for full results.`,
+      );
+    }
+
+    if (options['dotnet-target-framework']) {
+      debug(
+        'the dotnet-target-framework flag is ignored when falling back to the legacy scan.',
+      );
+    }
+
+    // fall through to the legacy scan below.
   }
 
   return nugetParser

--- a/lib/nuget-parser/cli/dotnet.ts
+++ b/lib/nuget-parser/cli/dotnet.ts
@@ -120,6 +120,19 @@ export async function validate(): Promise<string> {
   }
 }
 
+// Non-throwing check for whether the dotnet CLI is available on the system.
+// The underlying error is logged for diagnostics (visible with `-d`) so a failure
+// that isn't a plain "not on PATH" (e.g. a broken install) can be told apart.
+export async function isInstalled(): Promise<boolean> {
+  try {
+    await validate();
+    return true;
+  } catch (error: unknown) {
+    debug(`dotnet availability check failed: ${error}`);
+    return false;
+  }
+}
+
 export async function execute(
   args: string[],
   projectPath: string,

--- a/lib/nuget-parser/index.ts
+++ b/lib/nuget-parser/index.ts
@@ -345,9 +345,6 @@ Will attempt to build dependency graph anyway, but the operation might fail.`);
     );
   }
 
-  // Ensure `dotnet` is installed on the system or fail trying.
-  await dotnet.validate();
-
   // Write a .NET Framework Parser to a temporary directory for validating TargetFrameworks.
   const nugetFrameworksParserLocation = nugetFrameworksParser.generate();
   await dotnet.restore(nugetFrameworksParserLocation);

--- a/test/cli/dotnet.spec.ts
+++ b/test/cli/dotnet.spec.ts
@@ -256,6 +256,22 @@ describe('dotnet error handling', () => {
     }
   });
 
+  it('isInstalled returns true when dotnet is available', async () => {
+    jest
+      .spyOn(subprocess, 'execute')
+      .mockResolvedValue({ stdout: '8.0.100', stderr: '' });
+
+    expect(await dotnet.isInstalled()).toBe(true);
+  });
+
+  it('isInstalled returns false when dotnet is not available', async () => {
+    jest
+      .spyOn(subprocess, 'execute')
+      .mockRejectedValue(new Error('command not found: dotnet'));
+
+    expect(await dotnet.isInstalled()).toBe(false);
+  });
+
   it('sanitizes sensitive information in error messages', async () => {
     const mockError = {
       stdout: '',

--- a/test/inspect.spec.ts
+++ b/test/inspect.spec.ts
@@ -201,6 +201,9 @@ describe('when calling plugin.inspect with various configs', () => {
       buildDepTreeSpy = jest
         .spyOn(nugetParser, 'buildDepTreeFromFiles')
         .mockResolvedValue({ dependencies: {}, meta: {} });
+      // Default to dotnet being available so routing is deterministic regardless of
+      // the test environment. Tests covering the missing-dotnet path override this.
+      jest.spyOn(dotnet, 'isInstalled').mockResolvedValue(true);
     });
 
     afterEach(() => {
@@ -246,6 +249,35 @@ describe('when calling plugin.inspect with various configs', () => {
       await plugin.inspect(projectPath, manifestFile, options);
 
       expect(options['dotnet-runtime-resolution']).toBeUndefined();
+      expect(buildDepGraphSpy).not.toHaveBeenCalled();
+      expect(buildDepTreeSpy).toHaveBeenCalled();
+    });
+
+    it('uses runtime resolution when --dotnet-runtime-resolution is explicitly set and dotnet is installed', async () => {
+      const projectPath = './test/fixtures/dotnetcore/netcoreapp31/';
+      const manifestFile = 'obj/project.assets.json';
+      const options = {
+        'dotnet-runtime-resolution': true,
+      };
+
+      await plugin.inspect(projectPath, manifestFile, options);
+
+      expect(buildDepGraphSpy).toHaveBeenCalled();
+      expect(buildDepTreeSpy).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the legacy scan when cliDotnetRuntimeResolutionEnabled but dotnet is not installed', async () => {
+      jest.spyOn(dotnet, 'isInstalled').mockResolvedValue(false);
+
+      const projectPath = './test/fixtures/dotnetcore/netcoreapp31/';
+      const manifestFile = 'obj/project.assets.json';
+      const options = {
+        cliDotnetRuntimeResolutionEnabled: true,
+      };
+
+      await plugin.inspect(projectPath, manifestFile, options);
+
+      expect(options['dotnet-runtime-resolution']).toBe(true);
       expect(buildDepGraphSpy).not.toHaveBeenCalled();
       expect(buildDepTreeSpy).toHaveBeenCalled();
     });

--- a/test/inspect.spec.ts
+++ b/test/inspect.spec.ts
@@ -281,5 +281,22 @@ describe('when calling plugin.inspect with various configs', () => {
       expect(buildDepGraphSpy).not.toHaveBeenCalled();
       expect(buildDepTreeSpy).toHaveBeenCalled();
     });
+
+    it('errors when --dotnet-runtime-resolution is explicitly set but dotnet is not installed', async () => {
+      jest.spyOn(dotnet, 'isInstalled').mockResolvedValue(false);
+
+      const projectPath = './test/fixtures/dotnetcore/netcoreapp31/';
+      const manifestFile = 'obj/project.assets.json';
+      const options = {
+        'dotnet-runtime-resolution': true,
+      };
+
+      await expect(
+        plugin.inspect(projectPath, manifestFile, options),
+      ).rejects.toThrow('the dotnet CLI was not found');
+
+      expect(buildDepGraphSpy).not.toHaveBeenCalled();
+      expect(buildDepTreeSpy).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## What
When NuGet runtime resolution is requested but the `dotnet` CLI is unavailable at scan time, behaviour now depends on how it was requested:

- Implicit (`cliDotnetRuntimeResolutionEnabled`): warn and fall back to a legacy scan of the existing `project.assets.json` (used even if stale).
- Explicit (`--dotnet-runtime-resolution`): fail with an actionable error rather than silently returning a lower-fidelity result.

## Why
Runtime resolution depends on `dotnet` (restore, runtime assembly resolution, target-framework parsing). Some customers run Snyk in a CI step without `dotnet` — e.g. a stage after the build — and enabling runtime resolution broke scans that previously worked. Falling back to legacy restores that behaviour, while an explicit request still fails loudly so results aren't silently downgraded.