### PR TITLE
fix(ci): migrate to NPM OIDC trusted publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,7 +210,9 @@ jobs:
       - node_install_packages
       - run:
           name: Publish to GitHub
-          command: npx semantic-release
+          command: |
+            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            npx semantic-release
 
 workflows:
   version: 2
@@ -286,7 +288,9 @@ workflows:
 
       - release:
           name: Release
-          context: nodejs-app-release
+          context:
+            - nodejs-install
+            - github-release
           node_version: "lts"
           requires:
             - test-unix-unit


### PR DESCRIPTION
Migrates npm publishing to OIDC trusted publishing, removing the long-lived write NPM token from CI. The release job now fetches a short-lived OIDC token before `semantic-release` instead of relying on a stored token.

Note: the trusted-publisher configuration on the npm registry side must be completed before releases will succeed.