### PR TITLE
feat: target installed dotnet SDK tfm for the test app

### DIFF
--- a/lib/nuget-parser/csharp/nugetframeworks_parser.ts
+++ b/lib/nuget-parser/csharp/nugetframeworks_parser.ts
@@ -1,7 +1,14 @@
 import * as types from '../types';
 import * as generator from './generator';
 
-export function generate(): string {
+function targetFrameworkFromSdkVersion(sdkVersion: string): string {
+  const major = parseInt(sdkVersion.split('.')[0], 10);
+  return `net${major}.0`;
+}
+
+export function generate(sdkVersion: string): string {
+  const targetFramework = targetFrameworkFromSdkVersion(sdkVersion);
+
   const files: types.DotNetFile[] = [
     {
       name: 'Parse.csproj',
@@ -9,7 +16,7 @@ export function generate(): string {
 <Project Sdk='Microsoft.NET.Sdk'>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>${targetFramework}</TargetFramework>
     <Nullable>enable</Nullable>
     <RootNamespace>ShortNameToLongName</RootNamespace>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/lib/nuget-parser/index.ts
+++ b/lib/nuget-parser/index.ts
@@ -345,8 +345,12 @@ Will attempt to build dependency graph anyway, but the operation might fail.`);
     );
   }
 
+  // At this point we already know `dotnet` is installed on the system, this will not error.
+  const sdkVersion = await dotnet.validate();
+
   // Write a .NET Framework Parser to a temporary directory for validating TargetFrameworks.
-  const nugetFrameworksParserLocation = nugetFrameworksParser.generate();
+  const nugetFrameworksParserLocation =
+    nugetFrameworksParser.generate(sdkVersion);
   await dotnet.restore(nugetFrameworksParserLocation);
 
   // Access the path of this project, to ensure we get the right .csproj file, in case of multiples present

--- a/test/cli/dotnet.spec.ts
+++ b/test/cli/dotnet.spec.ts
@@ -120,7 +120,8 @@ class TestFixture {
   ])(
     'parses ShortName TFM to LongName using Nuget.Frameworks successfully',
     async ({ shortName, expected }) => {
-      const location = nugetFrameworksParser.generate();
+      const sdkVersion = await dotnet.validate();
+      const location = nugetFrameworksParser.generate(sdkVersion);
       await dotnet.restore(location);
       const response = await dotnet.run(location, [shortName]);
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

This PR builds the target-framework-testing app against the installed dotnet SDK main target framework, rather than `net6.0`.

The test app was introduced by [this PR](https://github.com/snyk/snyk-nuget-plugin/pull/175/changes), and is used to determine if the requested `TargetFramework` for scanning is supported by the currently installed SDK.
Recently we started to see errors with building this test app, as it requires the net6.0 build pack which might no longer be shipped with the latest versions of dotnet.

> dotnet run failed with error: 
The build failed. Fix the build errors and run again.
STDOUT:
/usr/share/dotnet/sdk/8.0.422/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.EolTargetFrameworks.targets(32,5): warning NETSDK1138: The target framework 'net6.0' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/dotnet-core-support for more information about the support policy. [/tmp/snyk-nuget-plugin-test-csharp-ku0w64/Parse.csproj]
/usr/share/dotnet/sdk/8.0.422/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(404,5): error NETSDK1127: The targeting pack Microsoft.NETCore.App is not installed. Please restore and try again. [/tmp/snyk-nuget-plugin-test-csharp-ku0w64/Parse.csproj]
. Command: dotnet, Args: ["run","--project","<TEMP>/snyk-nuget-plugin-test-csharp-ku0w64","net8.0"], Options: {}

#### How should this be manually tested?

The test suite already prevents regressions, but testing the exact failure scenario is not currently possible as it would require building the app on a machine with only net8.0.422 installed for example, while the [CI installs](https://github.com/snyk/snyk-nuget-plugin/blob/main/.circleci/config.yml#L81) multiple including net6.0.

#### Supporting data

- [Logs](https://app.datadoghq.com/logs?query=%2A%3Atargeting%5C%20pack%5C%20%2A%5C%20is%5C%20not%5C%20installed&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1781862936615&to_ts=1782467736615&live=true).
